### PR TITLE
WIP: support doc generation

### DIFF
--- a/src/build.cr
+++ b/src/build.cr
@@ -1,8 +1,15 @@
-{% if env("COMPILE_DRIVER").ends_with?("_spec.cr") %}
-  require "driver/driver-specs/runner"
-{% else %}
-  require "driver"
-{% end %}
+{% unless flag?("docs") %}
+  {% driver_src = env("COMPILE_DRIVER") %}
 
-# Dynamically require the desired driver
-{{ ("require \"../" + env("COMPILE_DRIVER") + "\"").id }}
+  {% if driver_src %}
+    {% if driver_src.ends_with?("_spec.cr") %}
+      require "driver/driver-specs/runner"
+    {% else %}
+      require "driver"
+    {% end %}
+
+    require "../{{driver_src.id}}"
+  {% else %}
+    {{ raise "Build target is not set. Use COMPILE_DRIVER env var to specify driver to build." }}
+  {% end %}
+{% end %}


### PR DESCRIPTION
Fixes an issue where running `crystal docs` would result in a compiler error and block doc generation. Functionality for build uses should be the same, but added a nicer compile time error for the missing env var too.