### PR TITLE
feat: use lib from host in docker-env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     volumes:
       - ./drivers/:/src/drivers/
       - ./repositories/:/src/repositories/
+      - ./lib/:/src/lib/
     environment:
       - REDIS_URL=redis://redis:6379
       - TZ=$TZ


### PR DESCRIPTION
Maps in the shards from the host as a volume. This enables adding to,
updating or otherwise changing dependancies during dev without forcing a
rebuild of the docker image.