### PR TITLE
feat(place:smtp): smtp driver

### DIFF
--- a/drivers/place/smtp.cr
+++ b/drivers/place/smtp.cr
@@ -1,0 +1,124 @@
+require "base64"
+require "email"
+require "uri"
+
+require "placeos-driver/interface/email"
+
+class Place::Smtp < PlaceOS::Driver
+  include PlaceOS::Driver::Interface::Email
+
+  descriptive_name "SMTP Mailer"
+  generic_name :Email
+  uri_base "https://smtp.host.com"
+  description %(sends emails via SMTP)
+
+  default_settings({
+    sender:   "support@place.tech",
+    host:     "smtp.host",
+    port:     587,
+    tls_mode: EMail::Client::TLSMode::STARTTLS,
+    username: "", # Username/Password for SMTP servers with basic authorization
+    password: "",
+  })
+
+  private def smtp_client : EMail::Client
+    @smtp_client ||= new_smtp_client
+  end
+
+  @smtp_client : EMail::Client?
+
+  @sender : String = "PlaceOS"
+  @username : String = ""
+  @password : String = ""
+  @host : String = "smtp.host"
+  @port : Int32 = 587
+  @tls_mode : EMail::Client::TLSMode = EMail::Client::TLSMode::STARTTLS
+
+  def on_load
+    on_update
+  end
+
+  def on_update
+    @username = setting?(String, :username) || ""
+    @password = setting?(String, :password) || ""
+    @sender = setting?(String, :sender) || "support@place.tech"
+    @host = setting?(String, :host) || "smtp.host"
+    @port = setting?(Int32, :port) || 587
+    @tls_mode = setting?(EMail::Client::TLSMode, :tls_mode) || EMail::Client::TLSMode::STARTTLS
+
+    @smtp_client = new_smtp_client
+  end
+
+  # Create and configure an SMTP client
+  private def new_smtp_client
+    email_config = EMail::Client::Config.new(@host, @port)
+    email_config.log = logger
+    email_config.client_name = "PlaceOS"
+
+    unless @username.empty? || @password.empty?
+      email_config.use_auth(@username, @password)
+    end
+
+    email_config.use_tls(@tls_mode)
+
+    EMail::Client.new(email_config)
+  end
+
+  def send_mail(
+    subject : String,
+    to : String | Array(String),
+    from : String | Array(String) | Nil = nil,
+    message_html : String = "",
+    message_plaintext : String = "",
+    attachments : Array(Attachment) = [] of Attachment,
+    resource_attachments : Array(ResourceAttachment) = [] of ResourceAttachment,
+    cc : String | Array(String) = [] of String,
+    bcc : String | Array(String) = [] of String
+  ) : Bool
+    to = {to} unless to.is_a?(Array)
+
+    from = {from} unless from.nil? || from.is_a?(Array)
+    cc = {cc} unless cc.nil? || cc.is_a?(Array)
+    bcc = {bcc} unless bcc.nil? || bcc.is_a?(Array)
+
+    message = EMail::Message.new
+
+    message.subject(subject)
+
+    message.sender(@sender)
+
+    if from.nil? || from.empty?
+      message.from(@sender)
+    else
+      from.each { |_from| message.from(_from) }
+    end
+
+    to.each { |_to| message.to(_to) }
+    bcc.each { |_bcc| message.bcc(_bcc) }
+    cc.each { |_cc| message.cc(_cc) }
+
+    message.message(message_plaintext) unless message_plaintext.nil?
+    message.message_html(message_html) unless message_html.nil?
+
+    # Traverse all attachments
+    {resource_attachments, attachments}.map(&.each).each.flatten.each do |attachment|
+      # Base64 decode to memory, then attach to email
+      attachment_io = IO::Memory.new
+      Base64.decode(attachment[:content], attachment_io)
+
+      case attachment
+      in Attachment
+        message.attach(attachment_io, file_name: attachment[:file_name])
+      in ResourceAttachment
+        message.message_resource(attachment_io, file_name: attachment[:file_name], cid: attachment[:content_id])
+      end
+    end
+
+    sent = false
+    smtp_client.start do
+      sent = send(message)
+    end
+
+    sent
+  end
+end

--- a/drivers/place/smtp_spec.cr
+++ b/drivers/place/smtp_spec.cr
@@ -1,0 +1,20 @@
+require "email"
+
+DriverSpecs.mock_driver "Place::Smtp" do
+  settings({
+    sender:   "support@place.tech",
+    host:     ENV["PLACE_SMTP_HOST"]? || "smtp.host",
+    port:     ENV["PLACE_SMTP_PORT"]?.try(&.to_i) || 587,
+    username: ENV["PLACE_SMTP_USER"]? || "", # Username/Password for SMTP servers with basic authorization
+    password: ENV["PLACE_SMTP_PASS"]? || "",
+  })
+
+  response = exec(
+    :send_mail,
+    subject: "Test Email",
+    to: ENV["PLACE_TEST_EMAIL"]? || "support@place.tech",
+    message_plaintext: "Hello!",
+  ).get
+
+  response.should be_true
+end

--- a/shard.lock
+++ b/shard.lock
@@ -28,6 +28,10 @@ shards:
     git: https://github.com/Sija/debug.cr.git
     version: 2.0.0
 
+  email:
+    git: https://github.com/arcage/crystal-email.git
+    version: 0.6.2
+
   etcd:
     git: https://github.com/place-labs/crystal-etcd.git
     version: 1.0.1
@@ -42,7 +46,7 @@ shards:
 
   google:
     git: https://github.com/PlaceOS/google.git
-    version: 2.3.0
+    version: 2.4.0
 
   habitat:
     git: https://github.com/luckyframework/habitat.git
@@ -50,7 +54,7 @@ shards:
 
   hound-dog:
     git: https://github.com/place-labs/hound-dog.git
-    version: 2.5.0
+    version: 2.5.1
 
   ipaddress:
     git: https://github.com/Sija/ipaddress.cr.git
@@ -74,7 +78,7 @@ shards:
 
   office365:
     git: https://github.com/PlaceOS/office365.git
-    version: 1.1.0
+    version: 1.1.1
 
   openssl_ext:
     git: https://github.com/stakach/openssl_ext.git
@@ -86,7 +90,7 @@ shards:
 
   place_calendar:
     git: https://github.com/PlaceOS/calendar.git
-    version: 2.0.1
+    version: 4.0.0
 
   placeos-compiler:
     git: https://github.com/placeos/compiler.git
@@ -94,7 +98,7 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 3.4.5
+    version: 3.5.1
 
   pool:
     git: https://github.com/ysbaddaden/pool.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: drivers
-version: 2.0.2
+version: 2.1.0
 crystal: 0.35.1
 
 # compile target
@@ -12,29 +12,32 @@ dependencies:
     github: spider-gazelle/action-controller
     version: ~> 3.1
 
-  placeos-driver:
-    github: placeos/driver
-    version: ~> 3.0
+  email:
+    github: arcage/crystal-email
+
+  exec_from:
+    github: place-labs/exec_from
+
+  jwt:
+    github: crystal-community/jwt
+
+  pinger:
+    github: spider-gazelle/pinger
+
+  place_calendar:
+    github: PlaceOS/calendar
 
   placeos-compiler:
     github: placeos/compiler
     version: ~> 2.0
 
-  exec_from:
-    github: place-labs/exec_from
+  placeos-driver:
+    github: placeos/driver
+    version: ~> 3.0
 
   rwlock:
     github: spider-gazelle/readers-writer
 
-  jwt:
-    github: crystal-community/jwt
-
   # Driver deps:
   telnet:
     github: spider-gazelle/telnet.cr
-
-  place_calendar:
-    github: PlaceOS/calendar
-
-  pinger:
-    github: spider-gazelle/pinger


### PR DESCRIPTION
An  SMTP driver using [crystal-email](https://github.com/arcage/crystal-email).
The SMTP client isn't neatly tested, we could use a [dummy SMTP server](https://github.com/russolsen/cr_fake_smtp).