### PR TITLE
fix(mdc): correct typo

### DIFF
--- a/drivers/samsung/displays/mdc_protocol.cr
+++ b/drivers/samsung/displays/mdc_protocol.cr
@@ -118,7 +118,7 @@ class Samsung::Displays::MDCProtocol < PlaceOS::Driver
 
   def power?(**options) : Bool
     do_send(Command::PanelMute, Bytes.empty, **options).get
-    !!self[:power]?.try(&.as_bool)
+    self[:power]?.try(&.as_bool)
   end
 
   # Mutes both audio/video


### PR DESCRIPTION
I think this is a typo as I don't think `!!` means anything in crystal