### PR TITLE
fix: Extron matrix driver

### DIFF
--- a/drivers/extron/matrix.cr
+++ b/drivers/extron/matrix.cr
@@ -81,7 +81,7 @@ class Extron::Matrix < PlaceOS::Driver
   end
 
   private def send(command, parser : SIS::Response::Parser(T)) forall T
-    send command, &.itself
+    send command, parser, &.itself
   end
 
   # Response callback for async responses.

--- a/drivers/extron/sis.cr
+++ b/drivers/extron/sis.cr
@@ -39,9 +39,9 @@ module Extron::SIS
     end
   end
 
-  alias Input = UInt8
+  alias Input = UInt16
 
-  alias Output = UInt8
+  alias Output = UInt16
 
   # Layers for targetting signal distribution operations.
   enum SwitchLayer : UInt8
@@ -49,6 +49,7 @@ module Extron::SIS
     Aud = 0x24 # '$'
     Vid = 0x25 # '%'
     RGB = 0x26 # '&'
+
     def includes_video?
       All || Vid || RGB
     end
@@ -64,10 +65,8 @@ module Extron::SIS
   # Struct for representing a broadcast signal path, or single output switch.
   record Switch, input : Input, layer : SwitchLayer
 
-  alias IOSize = UInt16
-
   # IO capacity for a switching layer.
-  record MatrixSize, inputs : IOSize, outputs : IOSize
+  record MatrixSize, inputs : Input, outputs : Output
 
   # IO capacity for a full device.
   record SwitcherInformation, video : MatrixSize, audio : MatrixSize

--- a/drivers/extron/sis/response.cr
+++ b/drivers/extron/sis/response.cr
@@ -67,9 +67,9 @@ module Extron::SIS::Response
   })
 
   MatrixSize = Parse.do({
-    inputs <= num(IOSize),
+    inputs <= num(Input),
     _ <= Parse.char('X'),
-    outputs <= num(IOSize),
+    outputs <= num(Output),
     Parse.const SIS::MatrixSize.new inputs, outputs,
   })
 


### PR DESCRIPTION
Resolves type issues and a missing response parser within the Extron Matrix driver.

The branch state in the originally merged PR was missing these. Due to the current lack of automated testing during merges, this would not have been caught.