### PR TITLE
Vergesense Driver

### DIFF
--- a/docs/writing-a-spec.md
+++ b/docs/writing-a-spec.md
@@ -15,7 +15,7 @@ From a driver code structure standpoint there is no difference between these typ
 During a test, the loaded module is loaded with a TCP transport, HTTP enabled and logic module capabilities.
 This allows for testing the full capabilities of any driver.
 
-The driver is lunched as it would be in production.
+The driver is launched as it would be in production.
 
 
 ## Expectations

--- a/drivers/vergesense/models.cr
+++ b/drivers/vergesense/models.cr
@@ -1,0 +1,63 @@
+require "json"
+
+# Vergesense Data Models
+module Vergesense
+  struct Building
+    include JSON::Serializable
+
+    property name : String
+    property building_ref_id : String
+    property address : String?
+  end
+
+  struct BuildingWithFloors
+    include JSON::Serializable
+
+    property building_ref_id : String
+    property floors : Array(Floor)
+  end
+
+  struct Floor
+    include JSON::Serializable
+
+    property floor_ref_id : String
+    property name : String
+    property capacity : UInt32?
+    property max_capacity : UInt32?
+    property spaces : Array(Space)
+  end
+
+  class Space
+    include JSON::Serializable
+
+    property building_ref_id : String?
+    property floor_ref_id : String?
+    property space_ref_id : String
+    property space_type : String?
+    property name : String?
+    property capacity : UInt32?
+    property max_capacity : UInt32?
+    property geometry : Geometry?
+    property people : People?
+    property timestamp : String?
+    property motion_detected : Bool?
+
+    def floor_key
+      "#{building_ref_id}-#{floor_ref_id}".strip
+    end
+  end
+
+  struct Geometry
+    include JSON::Serializable
+
+    property type : String
+    property coordinates : Array(Array(Array(Float64)))
+  end
+
+  struct People
+    include JSON::Serializable
+
+    property count : UInt32?
+    property coordinates : Array(Array(Array(Float64)))?
+  end
+end

--- a/drivers/vergesense/vergesense_api.cr
+++ b/drivers/vergesense/vergesense_api.cr
@@ -1,0 +1,151 @@
+module Vergesense; end
+
+require "./models"
+
+class Vergesense::VergesenseAPI < PlaceOS::Driver
+  # Discovery Information
+  descriptive_name "Vergesense API"
+  generic_name :VergesenseAPI
+  uri_base "https://api.vergesense.com"
+  description "for more information visit: https://vergesense.readme.io/"
+
+  default_settings({
+    vergesense_api_key: "VS-API-KEY",
+  })
+
+  @api_key : String = ""
+
+  @buildings : Array(Building) = [] of Building
+  @floors : Hash(String, Floor) = {} of String => Floor
+
+  @debug_payload : Bool = false
+  @completed_initial_sync : Bool = false
+
+  def on_load
+    on_update
+
+    # Unable to perform initial sync as the driver loads
+    # Waiting a small bit
+    schedule.in(200.milliseconds) { init_sync }
+  end
+
+  def on_update
+    @api_key = setting(String, :vergesense_api_key)
+    @debug_payload = setting?(Bool, :debug_payload) || false
+  end
+
+  def init_sync
+    begin
+      init_buildings
+
+      if @buildings
+        init_floors
+        init_spaces
+        init_floors_status
+        @completed_initial_sync = true
+      end
+    rescue e
+      logger.error { "failed to perform initial vergesense API sync\n#{e.inspect_with_backtrace}" }
+    end
+  end
+
+  EMPTY_HEADERS    = {} of String => String
+  SUCCESS_RESPONSE = {HTTP::Status::OK, EMPTY_HEADERS, nil}
+
+  # Webhook endpoint for space_report API, expects version 2
+  def space_report_api(method : String, headers : Hash(String, Array(String)), body : String)
+    logger.debug { "space_report API received: #{method},\nheaders #{headers},\nbody size #{body.size}" }
+    logger.debug { body } if @debug_payload
+
+    # Parse the data posted
+    begin
+      remote_space = Space.from_json(body)
+      logger.debug { "parsed vergesense payload" }
+
+      update_floor_space(remote_space)
+      update_single_floor_status(remote_space.floor_key, @floors[remote_space.floor_key]?)
+    rescue e
+      logger.error { "failed to parse vergesense space_report API payload\n#{e.inspect_with_backtrace}" }
+      logger.debug { "failed payload body was\n#{body}" }
+    end
+
+    # Return a 200 response
+    SUCCESS_RESPONSE
+  end
+
+  private def init_buildings
+    return if @completed_initial_sync
+
+    @buildings = Array(Building).from_json(get_request("/buildings"))
+  end
+
+  private def init_floors
+    return if @completed_initial_sync
+
+    @buildings.not_nil!.each do |building|
+      building_with_floors = BuildingWithFloors.from_json(get_request("/buildings/#{building.building_ref_id}"))
+      if building_with_floors
+        building_with_floors.floors.each do |floor|
+          floor_key = "#{building.building_ref_id}-#{floor.floor_ref_id}".strip
+          @floors[floor_key] = floor
+        end
+      end
+    end
+    @floors
+  end
+
+  private def init_spaces
+    return if @completed_initial_sync
+
+    spaces = Array(Space).from_json(get_request("/spaces"))
+    spaces.each do |remote_space|
+      update_floor_space(remote_space)
+    end
+
+    spaces
+  end
+
+  private def init_floors_status
+    return if @completed_initial_sync
+
+    @floors.each do |floor_key, floor|
+      update_single_floor_status(floor_key, floor)
+    end
+  end
+
+  private def update_single_floor_status(floor_key, floor)
+    if floor_key && floor
+      self[floor_key] = floor.not_nil!.to_json
+    end
+  end
+
+  private def update_floor_space(remote_space)
+    floor = @floors[remote_space.floor_key]?
+    if floor
+      floor_space = floor.spaces.find { |space| space.space_ref_id == remote_space.space_ref_id }
+      if floor_space
+        floor_space.building_ref_id = remote_space.building_ref_id
+        floor_space.floor_ref_id = remote_space.floor_ref_id
+        floor_space.people = remote_space.people
+        floor_space.motion_detected = remote_space.motion_detected
+        floor_space.timestamp = remote_space.timestamp
+      end
+    end
+  end
+
+  private def get_request(path)
+    begin
+      response = get(path,
+        headers: {
+          "vs-api-key" => @api_key,
+        }
+      )
+
+      if response.success?
+        response.body
+      else
+        raise "unexpected response #{response.status_code}\n#{response.body}"
+      end
+    end
+  end
+end

--- a/drivers/vergesense/vergesense_api.cr
+++ b/drivers/vergesense/vergesense_api.cr
@@ -34,6 +34,7 @@ class Vergesense::VergesenseAPI < PlaceOS::Driver
     @debug_payload = setting?(Bool, :debug_payload) || false
   end
 
+  # Performs initial sync by loading buildings / floors / spaces
   def init_sync
     begin
       init_buildings
@@ -113,12 +114,7 @@ class Vergesense::VergesenseAPI < PlaceOS::Driver
     end
   end
 
-  private def update_single_floor_status(floor_key, floor)
-    if floor_key && floor
-      self[floor_key] = floor.not_nil!.to_json
-    end
-  end
-
+  # Finds a space on a given floor and updates it in place.
   private def update_floor_space(remote_space)
     floor = @floors[remote_space.floor_key]?
     if floor
@@ -130,6 +126,12 @@ class Vergesense::VergesenseAPI < PlaceOS::Driver
         floor_space.motion_detected = remote_space.motion_detected
         floor_space.timestamp = remote_space.timestamp
       end
+    end
+  end
+
+  private def update_single_floor_status(floor_key, floor)
+    if floor_key && floor
+      self[floor_key] = floor.not_nil!.to_json
     end
   end
 

--- a/drivers/vergesense/vergesense_api_spec.cr
+++ b/drivers/vergesense/vergesense_api_spec.cr
@@ -1,5 +1,4 @@
 DriverSpecs.mock_driver "Vergesense::VergesenseAPI" do
-
   expect_http_request do |request, response|
     case request.path
     when "/buildings"

--- a/drivers/vergesense/vergesense_api_spec.cr
+++ b/drivers/vergesense/vergesense_api_spec.cr
@@ -1,0 +1,157 @@
+DriverSpecs.mock_driver "Vergesense::VergesenseAPI" do
+
+  expect_http_request do |request, response|
+    case request.path
+    when "/buildings"
+      response.status_code = 200
+      response << %([{
+      "name": "HQ 1",
+      "building_ref_id": "HQ1",
+      "address": null
+    }])
+    end
+  end
+
+  expect_http_request do |request, response|
+    case request.path
+    when "/buildings/HQ1"
+      response.status_code = 200
+      response << %({
+  "building_ref_id": "HQ1",
+  "capacity": 84,
+  "minimum_social_distance": 2.0,
+  "floors": [
+    {
+      "name": "Floor 1",
+      "floor_ref_id": "FL1",
+      "capacity": 84,
+      "max_capacity": 60,
+      "spaces": [
+        {
+          "name": "Conference Room 0721",
+          "space_ref_id": "CR_0721",
+          "space_type": "conference_room",
+          "capacity": 4,
+          "max_capacity": 3,
+          "sensors": [
+            {
+              "id": "L_000018",
+              "partitions": [
+                {
+                  "id": "L_000018/321"
+                }
+              ]
+            }
+          ],
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  93.850772,
+                  44.676952
+                ],
+                [
+                  93.850739,
+                  44.676929
+                ],
+                [
+                  93.850718,
+                  44.67695
+                ],
+                [
+                  93.850751,
+                  44.676973
+                ],
+                [
+                  93.850772,
+                  44.676952
+                ],
+                [
+                  93.850772,
+                  44.676952
+                ]
+              ]
+            ]
+          }
+        }
+      ]
+    }
+  ]
+})
+    end
+  end
+
+  expect_http_request do |request, response|
+    case request.path
+    when "/spaces"
+      response.status_code = 200
+      response << %([
+    {
+        "building_ref_id": "HQ1",
+        "floor_ref_id": "FL1",
+        "space_ref_id": "CR_0721",
+        "name": "Conference Room 0721",
+        "space_type": "conference_room",
+        "last_reports": [
+            {
+                "id": "W91-IGI",
+                "person_count": 2,
+                "signs_of_life": null,
+                "motion_detected": null,
+                "timestamp": "2019-07-29T18:42:19Z"
+            }
+        ],
+        "people": {
+            "count": 2,
+            "distances": {
+                "units": "meters",
+                "values": [2.42]
+            }
+        }
+    }
+])
+    end
+  end
+
+  # Testing initial status save
+  exec(:init_sync).get
+
+  status["HQ1-FL1"].should eq("{\"floor_ref_id\":\"FL1\",\"name\":\"Floor 1\",\"capacity\":84,\"max_capacity\":60,\"spaces\":[{\"building_ref_id\":\"HQ1\",\"floor_ref_id\":\"FL1\",\"space_ref_id\":\"CR_0721\",\"space_type\":\"conference_room\",\"name\":\"Conference Room 0721\",\"capacity\":4,\"max_capacity\":3,\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[93.850772,44.676952],[93.850739,44.676929],[93.850718,44.67695],[93.850751,44.676973],[93.850772,44.676952],[93.850772,44.676952]]]},\"people\":{\"count\":2}}]}")
+
+  # Testing webhook save
+  webhook_space_report_event = %({
+    "building_ref_id": "HQ1",
+    "floor_ref_id": "FL1",
+    "space_ref_id": "CR_0721",
+    "sensor_ids": ["VS0-123", "VS1-321"],
+    "person_count": 21,
+    "signs_of_life": null,
+    "motion_detected": true,
+    "event_type": "space_report",
+    "timestamp": "2019-08-21T21:10:25Z",
+    "people": {
+      "count": 21,
+      "coordinates": [
+        [
+          [
+            2.2673,
+            4.3891
+          ],
+          [
+            6.2573,
+            1.5303
+          ]
+        ]
+      ],
+      "distances": {
+        "units": "meters",
+        "values": [1.5]
+      }
+    }
+  })
+
+  exec(:space_report_api, method: "update", headers: {"test" => ["test"]}, body: webhook_space_report_event).get
+
+  status["HQ1-FL1"].should eq("{\"floor_ref_id\":\"FL1\",\"name\":\"Floor 1\",\"capacity\":84,\"max_capacity\":60,\"spaces\":[{\"building_ref_id\":\"HQ1\",\"floor_ref_id\":\"FL1\",\"space_ref_id\":\"CR_0721\",\"space_type\":\"conference_room\",\"name\":\"Conference Room 0721\",\"capacity\":4,\"max_capacity\":3,\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[93.850772,44.676952],[93.850739,44.676929],[93.850718,44.67695],[93.850751,44.676973],[93.850772,44.676952],[93.850772,44.676952]]]},\"people\":{\"count\":21,\"coordinates\":[[[2.2673,4.3891],[6.2573,1.5303]]]},\"timestamp\":\"2019-08-21T21:10:25Z\",\"motion_detected\":true}]}")
+end


### PR DESCRIPTION
Ref: #70

Notes:

Performs initial sync on load by hitting 3 different endpoints to get complete data.
* Buildings - https://vergesense.readme.io/reference#buildings
* Floors - https://vergesense.readme.io/reference#buildings-2
* Spaces -https://vergesense.readme.io/reference#spaces-1

Individual floor information is saved in the driver state as json string, under `"#{building_ref_id}-#{floor_ref_id}"` key.

Provides `space_report_api` method to be setup as trigger to receive webhook calls.

@stakach Please take a look and let me know if something is missing or needs updating. 

PS: I haven't added sensor information to Space, did we need that?