### PR TITLE
Biamp drivers

### DIFF
--- a/drivers/biamp/nexia.cr
+++ b/drivers/biamp/nexia.cr
@@ -1,0 +1,209 @@
+module Biamp; end
+
+class Biamp::Nexia < PlaceOS::Driver
+  # Discovery Information
+  tcp_port 23 # Telnet
+  descriptive_name "Biamp Nexia/Audia"
+  generic_name :Mixer
+
+  alias Ids = Array(UInt32) | UInt32
+
+  def on_load
+    # Nexia requires some breathing room
+    queue.wait = false
+    queue.delay = 30.milliseconds
+    transport.tokenizer = Tokenizer.new("\r\n", "\xFF\xFE\x01")
+  end
+
+  def on_update
+    # min -100
+    # max +12
+
+    self["fader_min"] = -36  # specifically for tonsley
+    self["fader_max"] = 12
+  end
+
+  def connected
+    send("\xFF\xFE\x01") # Echo off
+    do_send("GETD", 0, "DEVID")
+
+    schedule.every(60.seconds) do
+      do_send("GETD", 0, "DEVID")
+    end
+  end
+
+  def disconnected
+    schedule.clear
+  end
+
+  def preset(number : UInt32)
+    #
+    # Recall Device 0 Preset number 1001
+    # Device Number will always be 0 for Preset strings
+    # 1001 == minimum preset number
+    #
+    do_send("RECALL", 0, "PRESET", number)
+  end
+
+  # {1 => [2,3,5], 2 => [2,3,6]}, true
+  # Supports Standard, Matrix and Automixers
+  def mixer(id : UInt32, inouts : Hash(String, Float32 | Array(Float32)) | Array(Float32), mute : Bool = false, type : String = "matrix")
+    value = mute ? 0 : 1
+
+    if inouts.is_a? Hash
+      req = type == "matrix" ? "MMMUTEXP" : "SMMUTEXP"
+
+      inouts.each_key do |input|
+        outputs = inouts[input]
+        outs = ensure_array(outputs)
+
+        outs.each do |output|
+          do_send("SET", self["device_id"]?, req, id, input, output, value)
+        end
+      end
+    else # assume array (auto-mixer)
+      inouts.each do |input|
+        do_send("SET", self["device_id"]?, "AMMUTEXP", id, input, value)
+      end
+    end
+  end
+
+  FADERS = {
+    "fader"             => "FDRLVL",
+    "matrix_in"         => "MMLVLIN",
+    "matrix_out"        => "MMLVLOUT",
+    "matrix_crosspoint" => "MMLVLXP",
+    "stdmatrix_in"      => "SMLVLIN",
+    "stdmatrix_out"     => "SMLVLOUT",
+    "auto_in"           => "AMLVLIN",
+    "auto_out"          => "AMLVLOUT",
+    "io_in"             => "INPLVL",
+    "io_out"            => "OUTLVL",
+    "FDRLVL"            => "fader",
+    "MMLVLIN"           => "matrix_in",
+    "MMLVLOUT"          => "matrix_out",
+    "MMLVLXP"           => "matrix_crosspoint",
+    "SMLVLIN"           => "stdmatrix_in",
+    "SMLVLOUT"          => "stdmatrix_out",
+    "AMLVLIN"           => "auto_in",
+    "AMLVLOUT"          => "auto_out",
+    "INPLVL"            => "io_in",
+    "OUTLVL"            => "io_out",
+  }
+
+  def fader(fader_id : Ids, level : Float32, index : Int32 = 1, type : String = "fader")
+    fad_type = FADERS[type]
+
+    # value range: -100 ~ 12
+    faders = ensure_array(fader_id)
+    faders.each do |fad|
+      do_send("SETD", self["device_id"]?, fad_type, fad, index, level)
+    end
+  end
+
+  def faders(ids : Ids, level : Float32, index : Int32 = 1, type : String = "fader", **args)
+    fader(ids, level, index, type)
+  end
+
+  MUTES = {
+    "fader"         => "FDRMUTE",
+    "matrix_in"     => "MMMUTEIN",
+    "matrix_out"    => "MMMUTEOUT",
+    "auto_in"       => "AMMUTEIN",
+    "auto_out"      => "AMMUTEOUT",
+    "stdmatrix_in"  => "SMMUTEIN",
+    "stdmatrix_out" => "SMOUTMUTE",
+    "io_in"         => "INPMUTE",
+    "io_out"        => "OUTMUTE",
+    "FDRMUTE"       => "fader",
+    "MMMUTEIN"      => "matrix_in",
+    "MMMUTEOUT"     => "matrix_out",
+    "AMMUTEIN"      => "auto_in",
+    "AMMUTEOUT"     => "auto_out",
+    "SMMUTEIN"      => "stdmatrix_in",
+    "SMOUTMUTE"     => "stdmatrix_out",
+    "INPMUTE"       => "io_in",
+    "OUTMUTE"       => "io_out",
+  }
+
+  def mute(fader_id : Ids, val : Bool = true, index : Int32 = 1, type : String = "fader")
+    actual = val ? 1 : 0
+    mute_type = MUTES[type]
+
+    faders = ensure_array(fader_id)
+    faders.each do |fad|
+      do_send("SETD", self["device_id"]?, mute_type, fad, index, actual)
+    end
+  end
+
+  def mutes(ids : Ids, muted : Bool = true, index : Int32 = 1, type : String = "fader", **args)
+    mute(ids, muted, index, type)
+  end
+
+  def unmute(fader_id : Ids, index : Int32 = 1, type : String = "fader")
+    mute(fader_id, false, index, type)
+  end
+
+  def query_fader(fader_id : Ids, index : Int32 = 1, type : String = "fader")
+    fad = ensure_single(fader_id)
+    fad_type = FADERS[type]
+
+    do_send("GETD", self["device_id"]?, fad_type, fad, index)
+  end
+
+  def query_faders(ids : Ids, index : Int32 = 1, type : String = "fader", **args)
+    query_fader(ids, index, type)
+  end
+
+  def query_mute(fader_id : Ids, index : Int32 = 1, type : String = "fader")
+    fad = ensure_single(fader_id)
+    mute_type = MUTES[type]
+
+    do_send("GETD", self["device_id"]?, mute_type, fad, index)
+  end
+
+  def query_mutes(ids : Ids, index : Int32 = 1, type : String = "fader", **args)
+    query_mute(ids, index, type)
+  end
+
+  def received(data, task)
+    data = String.new(data)
+
+    if data =~ /-ERR/
+      return task.try &.abort
+    else
+      logger.debug { "Nexia responded #{data}" }
+    end
+
+    # --> "#SETD 0 FDRLVL 29 1 0.000000 +OK"
+    data = data.split(" ")
+    unless data[2].nil?
+      resp_type = data[2]
+
+      if resp_type == "DEVID"
+        # "#GETD 0 DEVID 1 "
+        self["device_id"] = data[-1].to_i
+      elsif MUTES.has_key?(resp_type)
+        type = MUTES[resp_type]
+        self["#{type}#{data[3]}_#{data[4]}_mute"] = data[5] == "1"
+      elsif FADERS.has_key?(resp_type)
+        type = FADERS[resp_type]
+        self["#{type}#{data[3]}_#{data[4]}"] = data[5]
+      end
+    end
+
+    task.try &.success
+  end
+
+  private def do_send(*args)
+    send("#{args.join(' ')} \n")
+  end
+
+  private def ensure_array(object)
+    object.is_a?(Array) ? object : [object]
+  end
+
+  private def ensure_single(object)
+    object.is_a?(Array) ? object[0] : object
+  end
+end

--- a/drivers/biamp/nexia_spec.cr
+++ b/drivers/biamp/nexia_spec.cr
@@ -6,47 +6,47 @@ DriverSpecs.mock_driver "Biamp::Nexia" do
   should_send("RECALL 0 PRESET 1001")
 
   exec(:fader, 1, -100)
-  responds("SETD  FDRLVL 1 1 -100.0 \r\n")
   should_send("SETD  FDRLVL 1 1 -100.0")
+  responds("SETD  FDRLVL 1 1 -100.0 \r\n")
   status["fader1_1"].should eq("-100.0")
 
   exec(:faders, 1, -75, 2, "matrix_in")
-  responds("SETD  MMLVLIN 1 2 -75.0 \r\n")
   should_send("SETD  MMLVLIN 1 2 -75.0")
+  responds("SETD  MMLVLIN 1 2 -75.0 \r\n")
   status["matrix_in1_2"].should eq("-75.0")
 
   exec(:mute, 1234, false, 3)
-  responds("SETD  FDRMUTE 1234 3 0 \r\n")
   should_send("SETD  FDRMUTE 1234 3 0")
+  responds("SETD  FDRMUTE 1234 3 0 \r\n")
   status["fader1234_3_mute"].should eq(false)
 
   exec(:mutes, 1234, true, 5, "auto_in")
-  responds("SETD  AMMUTEIN 1234 5 1 \r\n")
   should_send("SETD  AMMUTEIN 1234 5 1")
+  responds("SETD  AMMUTEIN 1234 5 1 \r\n")
   status["auto_in1234_5_mute"].should eq(true)
 
   exec(:unmute, 111)
-  responds("SETD  FDRMUTE 111 1 0 \r\n")
   should_send("SETD  FDRMUTE 111 1 0")
+  responds("SETD  FDRMUTE 111 1 0 \r\n")
   status["fader111_1_mute"].should eq(false)
 
   exec(:query_fader, 133)
-  responds("GETD  FDRLVL 133 1 -100.0 \r\n")
   should_send("GETD  FDRLVL 133 1 ")
+  responds("GETD  FDRLVL 133 1 -100.0 \r\n")
   status["fader133_1"].should eq("-100.0")
 
   exec(:query_faders, 144)
-  responds("GETD  FDRLVL 144 1 -80.0 \r\n")
   should_send("GETD  FDRLVL 144 1 ")
+  responds("GETD  FDRLVL 144 1 -80.0 \r\n")
   status["fader144_1"].should eq("-80.0")
 
   exec(:query_mute, 155)
-  responds("GETD  FDRMUTE 155 1 0 \r\n")
   should_send("GETD  FDRMUTE 155 1 ")
+  responds("GETD  FDRMUTE 155 1 0 \r\n")
   status["fader155_1_mute"].should eq(false)
 
   exec(:query_mutes, 166)
-  responds("GETD  FDRMUTE 166 1 1 \r\n")
   should_send("GETD  FDRMUTE 166 1 ")
+  responds("GETD  FDRMUTE 166 1 1 \r\n")
   status["fader166_1_mute"].should eq(true)
 end

--- a/drivers/biamp/nexia_spec.cr
+++ b/drivers/biamp/nexia_spec.cr
@@ -1,0 +1,52 @@
+DriverSpecs.mock_driver "Biamp::Nexia" do
+  should_send "\xFF\xFE\x01"
+  should_send("GETD 0 DEVID")
+
+  exec(:preset, 1001)
+  should_send("RECALL 0 PRESET 1001")
+
+  exec(:fader, 1, -100)
+  responds("SETD  FDRLVL 1 1 -100.0 \r\n")
+  should_send("SETD  FDRLVL 1 1 -100.0")
+  status["fader1_1"].should eq("-100.0")
+
+  exec(:faders, 1, -75, 2, "matrix_in")
+  responds("SETD  MMLVLIN 1 2 -75.0 \r\n")
+  should_send("SETD  MMLVLIN 1 2 -75.0")
+  status["matrix_in1_2"].should eq("-75.0")
+
+  exec(:mute, 1234, false, 3)
+  responds("SETD  FDRMUTE 1234 3 0 \r\n")
+  should_send("SETD  FDRMUTE 1234 3 0")
+  status["fader1234_3_mute"].should eq(false)
+
+  exec(:mutes, 1234, true, 5, "auto_in")
+  responds("SETD  AMMUTEIN 1234 5 1 \r\n")
+  should_send("SETD  AMMUTEIN 1234 5 1")
+  status["auto_in1234_5_mute"].should eq(true)
+
+  exec(:unmute, 111)
+  responds("SETD  FDRMUTE 111 1 0 \r\n")
+  should_send("SETD  FDRMUTE 111 1 0")
+  status["fader111_1_mute"].should eq(false)
+
+  exec(:query_fader, 133)
+  responds("GETD  FDRLVL 133 1 -100.0 \r\n")
+  should_send("GETD  FDRLVL 133 1 ")
+  status["fader133_1"].should eq("-100.0")
+
+  exec(:query_faders, 144)
+  responds("GETD  FDRLVL 144 1 -80.0 \r\n")
+  should_send("GETD  FDRLVL 144 1 ")
+  status["fader144_1"].should eq("-80.0")
+
+  exec(:query_mute, 155)
+  responds("GETD  FDRMUTE 155 1 0 \r\n")
+  should_send("GETD  FDRMUTE 155 1 ")
+  status["fader155_1_mute"].should eq(false)
+
+  exec(:query_mutes, 166)
+  responds("GETD  FDRMUTE 166 1 1 \r\n")
+  should_send("GETD  FDRMUTE 166 1 ")
+  status["fader166_1_mute"].should eq(true)
+end

--- a/drivers/biamp/tesira.cr
+++ b/drivers/biamp/tesira.cr
@@ -1,0 +1,225 @@
+require "telnet"
+
+module Biamp; end
+
+class Biamp::Tesira < PlaceOS::Driver
+  # Discovery Information
+  tcp_port 23 # Telnet
+  descriptive_name "Biamp Tesira"
+  generic_name :Mixer
+
+  default_settings({
+    no_password: true,
+    username:    "default",
+    password:    "default",
+  })
+
+  alias Num = Int32 | Float64
+  alias Ids = String | Array(String)
+
+  def on_load
+    # Nexia requires some breathing room
+    queue.wait = false
+    queue.delay = 30.milliseconds
+  end
+
+  def connected
+    @telnet = telnet = Telnet.new do |telnet_response|
+      transport.send telnet_response
+    end
+    transport.pre_processor { |bytes| telnet.buffer(bytes) }
+
+    if setting(Bool, :no_password)
+      do_send setting(String, :username) || "admin", wait: false, delay: 200.milliseconds, priority: 98
+      do_send setting(String, :password), wait: false, delay: 200.milliseconds, priority: 97
+    end
+    do_send "SESSION set verbose false", priority: 96
+
+    schedule.every(60.seconds) do
+      do_send "DEVICE get serialNumber", priority: 0
+    end
+  end
+
+  def disconnected
+    transport.tokenizer = nil
+    schedule.clear
+  end
+
+  def preset(number_or_name : String | Int32)
+    if number_or_name.is_a? Int32
+      do_send "DEVICE recallPreset #{number_or_name}"
+    else
+      do_send build(:DEVICE, :recallPresetByName, number_or_name)
+    end
+  end
+
+  def start_audio
+    do_send "DEVICE startAudio"
+  end
+
+  def reboot
+    do_send "DEVICE reboot"
+  end
+
+  def get_aliases
+    do_send "SESSION get aliases"
+  end
+
+  MIXERS = {
+    "matrix" => "crosspointLevelState",
+    "mixer"  => "crosspoint",
+  }
+
+  def mixer(id : String, inouts : Hash(Int32, Int32 | Array(Int32)) | Array(Int32), mute : Bool = false, type : String = "matrix")
+    mixer_type = MIXERS[type] || type
+
+    if inouts.is_a? Hash
+      inouts.each do |input, outs|
+        outputs = ensure_array(outs)
+        outputs.each do |output|
+          do_send build(id, :set, mixer_type, input, output, mute)
+        end
+      end
+    else # assume array (auto-mixer)
+      inouts.each do |input|
+        do_send_now build(id, :set, mixer_type, input, mute)
+      end
+    end
+  end
+
+  FADERS = {
+    "fader"             => "level",
+    "matrix_in"         => "inputLevel",
+    "matrix_out"        => "outputLevel",
+    "matrix_crosspoint" => "crosspointLevel",
+    "level"             => "fader",
+    "inputLevel"        => "matrix_in",
+    "outputLevel"       => "matrix_out",
+    "crosspointLevel"   => "matrix_crosspoint",
+  }
+
+  def fader(fader_id : Ids, level : Num | Bool, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    # value range: -100 ~ 12
+    fader_type = FADERS[type] || type
+
+    fader_ids = ensure_array(fader_id)
+    indicies = ensure_array(index)
+    fader_ids.each do |fad|
+      indicies.each do |i|
+        do_send_now build(fad, :set, fader_type, i, level)
+        self["#{fader_type}_#{fad}_#{i}"] = level
+      end
+    end
+  end
+
+  # Named params version
+  def faders(ids : Ids, level : Num | Bool, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    fader(ids, level, index, type)
+  end
+
+  MUTES = {
+    "fader"      => "mute",
+    "matrix_in"  => "inputMute",
+    "matrix_out" => "outputMute",
+    "mute"       => "fader",
+    "inputMute"  => "matrix_in",
+    "outputMute" => "matrix_out",
+  }
+
+  def mute(fader_id : Ids, value : Bool = true, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    mute_type = MUTES[type] || type
+
+    fader_ids = ensure_array(fader_id)
+    indicies = ensure_array(index)
+    fader_ids.each do |fad|
+      indicies.each do |i|
+        do_send_now build(fad, :set, mute_type, i, value)
+        self["#{mute_type}_#{fad}_#{i}_mute"] = value
+      end
+    end
+  end
+
+  # Named params version
+  def mutes(ids : Ids, muted : Bool, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    mute(ids, muted, index, type)
+  end
+
+  def unmute(fader_id : Ids, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    mute(fader_id, false, index, type)
+  end
+
+  def query_fader(fader_id : Ids, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    fad_type = FADERS[type] || type
+    fader_id = ensure_array(fader_id)[0]
+    index = ensure_array(index)[0]
+
+    do_send build(fader_id, :get, fad_type, index)
+  end
+
+  # Named params version
+  def query_faders(ids : Ids, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    query_fader(ids, index, type)
+  end
+
+  def query_mute(fader_id : Ids, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    mute_type = MUTES[type] || type
+    fader_id = ensure_array(fader_id)[0]
+    index = ensure_array(index)[0]
+
+    do_send build(fader_id, :get, mute_type, index)
+  end
+
+  # Named params version
+  def query_mutes(ids : Ids, index : Int32 | Array(Int32) = 1, type : String = "fader")
+    query_mute(ids, index, type)
+  end
+
+  def received(data, task)
+    data = String.new(data).strip
+
+    logger.debug { "Tesira responded -> data: #{data}" }
+    result = data.split(" ")
+
+    if result[0] == "-"
+      task.try(&.abort)
+    end
+
+    if data =~ /login:|server/i
+      transport.tokenizer = Tokenizer.new "\r\n"
+    end
+
+    task.try(&.success)
+  end
+
+  private def build(*args)
+    cmd = ""
+    args.each do |arg|
+      data = arg.to_s
+      next if data.blank?
+      cmd = cmd + " " if cmd.size > 0
+
+      if data.includes? " "
+        cmd = cmd + "\""
+        cmd = cmd + data
+        cmd = cmd + "\""
+      else
+        cmd = cmd + data
+      end
+    end
+    cmd
+  end
+
+  private def do_send(command, **options)
+    logger.debug { "requesting #{command}" }
+    send @telnet.not_nil!.prepare(command), **options
+  end
+
+  private def do_send_now(command)
+    logger.debug { "requesting #{command}" }
+    transport.send @telnet.not_nil!.prepare(command)
+  end
+
+  private def ensure_array(object)
+    object.is_a?(Array) ? object : [object]
+  end
+end

--- a/drivers/biamp/tesira_spec.cr
+++ b/drivers/biamp/tesira_spec.cr
@@ -1,0 +1,37 @@
+DriverSpecs.mock_driver "Biamp::Tesira" do
+  transmit "login: "
+  should_send "default\r\n"
+  should_send "default\r\n"
+  should_send "SESSION set verbose false\r\n"
+
+  exec(:preset, 1001)
+  should_send "DEVICE recallPreset 1001"
+
+  exec(:preset, "1001-test")
+  should_send "DEVICE recallPresetByName 1001-test"
+
+  exec(:start_audio)
+  should_send "DEVICE startAudio"
+
+  exec(:reboot)
+  should_send "DEVICE reboot"
+
+  exec(:get_aliases)
+  should_send "SESSION get aliases"
+
+  exec(:mixer, "123", [1])
+  should_send "123 set crosspointLevelState 1 false"
+
+  exec(:fader, "Fader123", 11)
+  responds("+OK\r\n")
+  should_send "Fader123 set level 1 11"
+  status["level_Fader123_1"] = 11
+
+  exec(:mute, "Fader123")
+  responds("+OK\r\n")
+  should_send "Fader123 set mute 1 true"
+  status["level_Fader123_1_mute"] = true
+
+  exec(:query_fader, "Fader123")
+  should_send "Fader123 get level 1"
+end

--- a/drivers/biamp/tesira_spec.cr
+++ b/drivers/biamp/tesira_spec.cr
@@ -23,13 +23,13 @@ DriverSpecs.mock_driver "Biamp::Tesira" do
   should_send "123 set crosspointLevelState 1 false"
 
   exec(:fader, "Fader123", 11)
-  responds("+OK\r\n")
   should_send "Fader123 set level 1 11"
+  responds("+OK\r\n")
   status["level_Fader123_1"] = 11
 
   exec(:mute, "Fader123")
-  responds("+OK\r\n")
   should_send "Fader123 set mute 1 true"
+  responds("+OK\r\n")
   status["level_Fader123_1_mute"] = true
 
   exec(:query_fader, "Fader123")


### PR DESCRIPTION
Has drivers for:

* Tesira
* Nexia

Few notes on Tesira implementation. 

In the ruby version https://github.com/acaprojects/ruby-engine-drivers/blob/beta/modules/biamp/tesira.rb#L233, we rely on `command` parameter in `received` method to figure out the correct status to set. In crystal version of `received` method we don't have `command`.

So to work around that issue we have opted to `send` without queueing and change status rightaway: https://github.com/PlaceOS/drivers/compare/master...websymphony:aca_111_biamp_drivers?expand=1#diff-dd0234e1626a32d2221be3e61d7ebb54c50b558a12dbc9eabbe65fdf5ceb4bffR109