### PR TITLE
build(docker-compose): remove the container_name key for redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   redis:
     image: eqalpha/keydb
     restart: always
-    container_name: redis
     hostname: redis
     environment:
       - TZ=$TZ


### PR DESCRIPTION
Use of the `container_name` key is not necessary here, and may lead to container name conflicts.