### PR TITLE
Resolve Lenel Open Access driver build issues

### DIFF
--- a/drivers/lenel/open_access/client.cr
+++ b/drivers/lenel/open_access/client.cr
@@ -39,20 +39,20 @@ class Lenel::OpenAccess::Client
   def version
     ~transport.get(
       path: "/version?version=1.0",
-    ) >> {
+    ) >> NamedTuple(
       product_name:    String,
       product_version: String,
-    }
+    )
   end
 
   # Enumerates the directories available for auth.
   def directories
     (~transport.get(
       path: "/directories?version=1.0"
-    ) >> {
+    ) >> NamedTuple(
       total_items: Int32,
       item_list:   Array({property_value_map: {ID: String, Name: String, directory_type: Int32}}),
-    })[:item_list].map { |item| item[:property_value_map] }
+    ))[:item_list].map { |item| item[:property_value_map] }
   end
 
   # Creates a new auth session.
@@ -64,10 +64,10 @@ class Lenel::OpenAccess::Client
     ~transport.post(
       path: "/authentication?version=1.0",
       body: args.to_h.compact.to_json,
-    ) >> {
+    ) >> NamedTuple(
       session_token:         String,
       token_expiration_time: Time,
-    }
+    )
   end
 
   # Removes an auth session.
@@ -121,14 +121,14 @@ class Lenel::OpenAccess::Client
     end
     (~transport.get(
       path: "/instances?version=1.0&#{params}",
-    ) >> {
+    ) >> NamedTuple(
       page_number: Int32?,
       page_size:   Int32?,
       total_pages: Int32,
       total_items: Int32,
       count:       Int32,
       item_list:   Array(T),
-    })[:item_list]
+    ))[:item_list]
   end
 
   # Counts the number of instances of *entity*.
@@ -138,7 +138,9 @@ class Lenel::OpenAccess::Client
     params = HTTP::Params.encode args.merge type_name: T.type_name
     (~transport.get(
       path: "/count?version=1.0&#{params}"
-    ) >> {total_items: Int32})[:total_items]
+    ) >> NamedTuple(
+      total_items: Int32
+    ))[:total_items]
   end
 
   # Updates a record of *entity*. Passed properties must include the types key and

--- a/drivers/lenel/open_access/client.cr
+++ b/drivers/lenel/open_access/client.cr
@@ -40,7 +40,7 @@ class Lenel::OpenAccess::Client
     ~transport.get(
       path: "/version?version=1.0",
     ) >> NamedTuple(
-      product_name:    String,
+      product_name: String,
       product_version: String,
     )
   end
@@ -51,7 +51,7 @@ class Lenel::OpenAccess::Client
       path: "/directories?version=1.0"
     ) >> NamedTuple(
       total_items: Int32,
-      item_list:   Array({property_value_map: {ID: String, Name: String, directory_type: Int32}}),
+      item_list: Array({property_value_map: {ID: String, Name: String, directory_type: Int32}}),
     ))[:item_list].map { |item| item[:property_value_map] }
   end
 
@@ -65,7 +65,7 @@ class Lenel::OpenAccess::Client
       path: "/authentication?version=1.0",
       body: args.to_h.compact.to_json,
     ) >> NamedTuple(
-      session_token:         String,
+      session_token: String,
       token_expiration_time: Time,
     )
   end
@@ -123,11 +123,11 @@ class Lenel::OpenAccess::Client
       path: "/instances?version=1.0&#{params}",
     ) >> NamedTuple(
       page_number: Int32?,
-      page_size:   Int32?,
+      page_size: Int32?,
       total_pages: Int32,
       total_items: Int32,
-      count:       Int32,
-      item_list:   Array(T),
+      count: Int32,
+      item_list: Array(T),
     ))[:item_list]
   end
 
@@ -138,9 +138,7 @@ class Lenel::OpenAccess::Client
     params = HTTP::Params.encode args.merge type_name: T.type_name
     (~transport.get(
       path: "/count?version=1.0&#{params}"
-    ) >> NamedTuple(
-      total_items: Int32
-    ))[:total_items]
+    ) >> NamedTuple(total_items: Int32))[:total_items]
   end
 
   # Updates a record of *entity*. Passed properties must include the types key and

--- a/shard.lock
+++ b/shard.lock
@@ -73,6 +73,10 @@ shards:
     git: https://github.com/caspiano/http-params-serializable.git
     version: 0.4.1+git.commit.c87119117af3d2db11af22ad799ccf77072e6a8b
 
+  inactive-support:
+    git: https://github.com/spider-gazelle/inactive-support.git
+    version: 0.1.1
+
   ipaddress:
     git: https://github.com/sija/ipaddress.cr.git
     version: 0.2.1

--- a/shard.yml
+++ b/shard.yml
@@ -18,6 +18,9 @@ dependencies:
   exec_from:
     github: place-labs/exec_from
 
+  inactive-support:
+    github: spider-gazelle/inactive-support
+
   jwt:
     github: crystal-community/jwt
 


### PR DESCRIPTION
Re-adds a [dependency that was dropped](https://github.com/PlaceOS/drivers/commit/162631230c365b40c9ed40b3d46ce1b523196f33#diff-cbaa8062ee0fcfb5af8adfd98f69af4766b9ad5bb5e79158abe8da34f6fd7de0L64-L66).

Reverts semantically important changes introduced in #149.

Resolves #151.