### PR TITLE
feat(global_cache): conform to electrical relay interface

### DIFF
--- a/drivers/global_cache/gc_100.cr
+++ b/drivers/global_cache/gc_100.cr
@@ -1,4 +1,8 @@
+require "placeos-driver/interface/electrical_relay"
+
 class GlobalCache::Gc100 < PlaceOS::Driver
+  include Interface::ElectricalRelay
+
   # Discovery Information
   tcp_port 4999
   descriptive_name "GlobalCache IO Gateway"
@@ -39,7 +43,7 @@ class GlobalCache::Gc100 < PlaceOS::Driver
     do_send("getdevices") # , :max_waits => 100)
   end
 
-  def relay(index : Int32, state : Bool, **options)
+  def relay(state : Bool, index : Int32 = 0, **options)
     if index < self[:num_relays].as_i
       relays = (self[:relay_config]["relay"]? || self[:relay_config]["relaysensor"]?).not_nil!.as_h
       logger.debug { "relays = #{relays}" }

--- a/drivers/global_cache/gc_100_spec.cr
+++ b/drivers/global_cache/gc_100_spec.cr
@@ -19,7 +19,7 @@ DriverSpecs.mock_driver "GlobalCache::Gc100" do
     "2:1" => ["relay", 0], "2:2" => ["relay", 1], "2:3" => ["relay", 2], "1:1" => ["relaysensor", 0], "1:2" => ["relaysensor", 1], "3:1" => ["ir", 0],
   })
 
-  exec(:relay, 1, true)
+  exec(:relay, true, 1)
   should_send("setstate,2:2,1\r")
   responds("state,2:2,1\r")
   status[:relay1].should eq(true)

--- a/shard.lock
+++ b/shard.lock
@@ -147,7 +147,7 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 5.0.10
+    version: 5.1.1
 
   placeos-models:
     git: https://github.com/placeos/models.git


### PR DESCRIPTION
Adds `PlaceOS::Driver:Interface::ElectricalRelay`  to the global cache driver