### PR TITLE
feat(smtp): add setting to ignore cert validation

### DIFF
--- a/drivers/place/smtp.cr
+++ b/drivers/place/smtp.cr
@@ -19,6 +19,7 @@ class Place::Smtp < PlaceOS::Driver
     # host:     "smtp.host",
     # port:     587,
     tls_mode: EMail::Client::TLSMode::STARTTLS.to_s,
+    ssl_verify_ignore: false,
     username: "", # Username/Password for SMTP servers with basic authorization
     password: "",
 
@@ -41,6 +42,7 @@ class Place::Smtp < PlaceOS::Driver
   @port : Int32 = 587
   @tls_mode : EMail::Client::TLSMode = EMail::Client::TLSMode::STARTTLS
   @send_lock : Mutex = Mutex.new
+  @ssl_verify_ignore : Bool = false
 
   def on_load
     on_update
@@ -62,6 +64,7 @@ class Place::Smtp < PlaceOS::Driver
     @host = setting?(String, :host) || host
     @port = setting?(Int32, :port) || port
     @tls_mode = setting?(EMail::Client::TLSMode, :tls_mode) || tls_mode
+    @ssl_verify_ignore = setting?(Bool, :ssl_verify_ignore) || false
 
     @smtp_client = new_smtp_client
 
@@ -79,6 +82,7 @@ class Place::Smtp < PlaceOS::Driver
     end
 
     email_config.use_tls(@tls_mode)
+    email_config.tls_context.verify_mode = OpenSSL::SSL::VerifyMode::None
 
     EMail::Client.new(email_config)
   end

--- a/drivers/place/smtp.cr
+++ b/drivers/place/smtp.cr
@@ -82,7 +82,7 @@ class Place::Smtp < PlaceOS::Driver
     end
 
     email_config.use_tls(@tls_mode)
-    email_config.tls_context.verify_mode = OpenSSL::SSL::VerifyMode::None
+    email_config.tls_context.verify_mode = OpenSSL::SSL::VerifyMode::None if @ssl_verify_ignore
 
     EMail::Client.new(email_config)
   end


### PR DESCRIPTION
Ideally it would have been better to add a setting called `setting?(OpenSSL::SSL::VerifyMode, :ssl_verify_mode)` so we could specify other enums/values of `OpenSSL::SSL::VerifyMode` instead of `setting?(Bool, :ssl_verify_ignore)` but that doesn't work because of this issue https://github.com/crystal-lang/crystal/pull/7382