### PR TITLE
Fix broken require from `inactive-support`

### DIFF
--- a/drivers/lenel/open_access/client.cr
+++ b/drivers/lenel/open_access/client.cr
@@ -2,7 +2,7 @@ require "http/client"
 require "http/params"
 require "responsible"
 require "uri"
-require "inactive-support/macro/args"
+require "inactive-support/args"
 
 require "./models"
 require "./error"


### PR DESCRIPTION
Resolves a breaking API change / layout change in upstream dep.

Introduced in d2fc0cccce54d4611ec68db7e8f9600aa8600202.