### PR TITLE
feat(place/visitor_mailer): add host mailbox to QR data

### DIFF
--- a/drivers/place/visitor_mailer.cr
+++ b/drivers/place/visitor_mailer.cr
@@ -120,7 +120,7 @@ class Place::VisitorMailer < PlaceOS::Driver
 
     local_start_time = Time.unix(event_start).in(@time_zone)
 
-    qr_png = mailer.generate_png_qrcode(text: "VISIT:#{visitor_email},#{system_id},#{event_id}", size: 256).get.as_s
+    qr_png = mailer.generate_png_qrcode(text: "VISIT:#{visitor_email},#{system_id},#{event_id},#{host_email}", size: 256).get.as_s
 
     mailer.send_template(
       visitor_email,


### PR DESCRIPTION
Staff-api event/checkin request will [now support](https://github.com/place-labs/staff-api/commit/0794fd08336746a36e1e78f05e575dff34345f84) a new optional `host_mailbox` param, which must be used when the EVENT ID supplied is the HOST mailbox event ID instead of the room mailbox event id. This is the case for the QR code that this driver generates.

So apps (frontends) that use the QR code generated by this driver will also need a small change to read and use the 4th comma seperated data item in the qr code, and include it in checkin POSTs as a new param`host_mailbox=_`