### PR TITLE
chore(shard.lock): bump driver

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -11,7 +11,7 @@ shards:
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git
-    version: 3.0.0
+    version: 3.1.1
 
   awscr-signer:
     git: https://github.com/taylorfinnell/awscr-signer.git
@@ -74,8 +74,8 @@ shards:
     version: 2.9.0
 
   http-params-serializable:
-    git: https://github.com/caspiano/http-params-serializable.git
-    version: 0.4.1+git.commit.c87119117af3d2db11af22ad799ccf77072e6a8b
+    git: https://github.com/place-labs/http-params-serializable.git
+    version: 0.5.0
 
   inactive-support:
     git: https://github.com/spider-gazelle/inactive-support.git
@@ -123,7 +123,7 @@ shards:
 
   office365:
     git: https://github.com/placeos/office365.git
-    version: 1.13.5
+    version: 1.13.6
 
   openssl_ext:
     git: https://github.com/spider-gazelle/openssl_ext.git
@@ -147,7 +147,7 @@ shards:
 
   placeos:
     git: https://github.com/placeos/crystal-client.git
-    version: 2.4.0
+    version: 2.4.1
 
   placeos-compiler:
     git: https://github.com/placeos/compiler.git
@@ -155,7 +155,7 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 5.3.13
+    version: 5.3.14
 
   placeos-log-backend:
     git: https://github.com/place-labs/log-backend.git
@@ -163,7 +163,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.5.0
+    version: 5.6.0
 
   pool:
     git: https://github.com/ysbaddaden/pool.git
@@ -178,12 +178,12 @@ shards:
     version: 1.0.2
 
   redis:
-    git: https://github.com/maiha/crystal-redis.git
-    version: 2.6.0
+    git: https://github.com/stefanwille/crystal-redis.git
+    version: 2.7.0
 
   redis-cluster:
     git: https://github.com/caspiano/redis-cluster.cr.git
-    version: 0.8.4
+    version: 0.8.5
 
   rendezvous-hash:
     git: https://github.com/caspiano/rendezvous-hash.git
@@ -203,7 +203,7 @@ shards:
 
   retriable: # Overridden
     git: https://github.com/sija/retriable.cr.git
-    version: 0.2.3
+    version: 0.2.4
 
   rwlock:
     git: https://github.com/spider-gazelle/readers-writer.git


### PR DESCRIPTION
Bump driver to fix a few failing compilations