### PR TITLE
feat(lenel/openaccess): add more funcs; make badge response fields op…

### DIFF
--- a/drivers/lenel/open_access.cr
+++ b/drivers/lenel/open_access.cr
@@ -224,7 +224,7 @@ class Lenel::OpenAccess < PlaceOS::Driver
   def delete_badges(badgekeys : Array(Int32)) : Int
     deleted : UInt32 = 0
     badgekeys.each do |badgekey|
-      delete(badgekey)
+      delete(badgekey.to_s)
       deleted += 1
     end
     deleted

--- a/drivers/lenel/open_access.cr
+++ b/drivers/lenel/open_access.cr
@@ -115,6 +115,34 @@ class Lenel::OpenAccess < PlaceOS::Driver
     client.lookup BadgeType
   end
 
+  # List badges belonging to a cardholder
+  @[Security(Level::Support)]
+  def list_badges(personid : Int32)
+    client.lookup Badge, filter: %(personid = #{personid})
+  end
+
+  # Get badge by badgekey (instead of id)
+  # Note: id is the number in the QR data or burnt to the swipe card. badgekey is Lenel's primary key for badges
+  @[Security(Level::Support)]
+  def lookup_badge_key(badgekey : Int32)
+    badges = client.lookup Badge, filter: %(badgekey = #{badgekey})
+    if badges.size > 1
+      logger.warn { "duplicate records exist for #{badgekey}" }
+    end
+    badges.first?
+  end
+
+  # Get badge by id (instead of badgekey)
+  @[Security(Level::Support)]
+  def lookup_badge_id(id : Int64)
+    badges = client.lookup Badge, filter: %(id = #{id})
+    if badges.size > 1
+      logger.warn { "duplicate records exist for #{id}" }
+    end
+    badges.first?
+  end
+
+
   # Creates a new badge of the specied *type*, belonging to *personid* with a
   # specific *id*.
   #
@@ -128,15 +156,80 @@ class Lenel::OpenAccess < PlaceOS::Driver
     activate : Time? = nil,
     deactivate : Time? = nil
   )
-    logger.debug { "creating badge badge for cardholder #{personid}" }
+    logger.debug { "creating badge for cardholder #{personid}" }
     client.create Badge, **args
   end
+
+  def create_badge_epoch(
+    type : Int32,
+    id : Int64,
+    personid : Int32,
+    activate_epoch : Int32,
+    deactivate_epoch : Int32,
+    uselimit : Int32? = nil
+  )
+    activate = Time.unix(activate_epoch).in Time::Location.load("Asia/Dubai")
+    deactivate = Time.unix(deactivate_epoch).in Time::Location.load("Asia/Dubai")
+    logger.debug { "Creating badge for cardholder #{personid}, valid from: #{activate} til #{deactivate}" }
+    
+    create_badge(
+      type: type,
+      id: id,
+      personid: personid,
+      activate: activate,
+      deactivate: deactivate,
+      uselimit: uselimit
+    )
+  end
+
+  @[Security(Level::Administrator)]
+  def update_badge(
+    badgekey : Int32,
+    id : Int64? = nil,
+    uselimit : Int32? = nil,
+    activate : Time? = nil,
+    deactivate : Time? = nil
+  )
+    logger.debug { "Updating badge #{badgekey}" }
+    client.update Badge, **args
+  end
+
+  @[Security(Level::Administrator)]
+  def update_badge_epoch(
+    badgekey : Int32,
+    activate_epoch : Int32,
+    deactivate_epoch : Int32,
+    id : Int64? = nil,
+    uselimit : Int32? = nil,
+  )
+    activate = Time.unix(activate_epoch).in Time::Location.load("Asia/Dubai")
+    deactivate = Time.unix(deactivate_epoch).in Time::Location.load("Asia/Dubai")
+    logger.debug { "Updating badge #{badgekey} with id #{id} valid from: #{activate} til #{deactivate}" }    
+
+    update_badge(
+      badgekey: badgekey,
+      id: id,
+      activate: activate,
+      deactivate: deactivate,
+      uselimit: uselimit
+    )
+  end
+
 
   # Deletes a badge with the specified *badgekey*.
   @[Security(Level::Administrator)]
   def delete_badge(badgekey : Int32) : Nil
     logger.debug { "deleting badge #{badgekey}" }
     client.delete Badge, **args
+  end
+
+  def delete_badges(badgekeys : Array(Int32)) : Int
+    deleted : UInt32 = 0
+    badgekeys.each do |badgekey|
+      delete(badgekey)
+      deleted += 1
+    end
+    deleted
   end
 
   # Lookup a cardholder by *email* address.

--- a/drivers/lenel/open_access.cr
+++ b/drivers/lenel/open_access.cr
@@ -142,7 +142,6 @@ class Lenel::OpenAccess < PlaceOS::Driver
     badges.first?
   end
 
-
   # Creates a new badge of the specied *type*, belonging to *personid* with a
   # specific *id*.
   #
@@ -171,7 +170,7 @@ class Lenel::OpenAccess < PlaceOS::Driver
     activate = Time.unix(activate_epoch).in Time::Location.load("Asia/Dubai")
     deactivate = Time.unix(deactivate_epoch).in Time::Location.load("Asia/Dubai")
     logger.debug { "Creating badge for cardholder #{personid}, valid from: #{activate} til #{deactivate}" }
-    
+
     create_badge(
       type: type,
       id: id,
@@ -200,11 +199,11 @@ class Lenel::OpenAccess < PlaceOS::Driver
     activate_epoch : Int32,
     deactivate_epoch : Int32,
     id : Int64? = nil,
-    uselimit : Int32? = nil,
+    uselimit : Int32? = nil
   )
     activate = Time.unix(activate_epoch).in Time::Location.load("Asia/Dubai")
     deactivate = Time.unix(deactivate_epoch).in Time::Location.load("Asia/Dubai")
-    logger.debug { "Updating badge #{badgekey} with id #{id} valid from: #{activate} til #{deactivate}" }    
+    logger.debug { "Updating badge #{badgekey} with id #{id} valid from: #{activate} til #{deactivate}" }
 
     update_badge(
       badgekey: badgekey,
@@ -214,7 +213,6 @@ class Lenel::OpenAccess < PlaceOS::Driver
       uselimit: uselimit
     )
   end
-
 
   # Deletes a badge with the specified *badgekey*.
   @[Security(Level::Administrator)]

--- a/drivers/lenel/open_access/models.cr
+++ b/drivers/lenel/open_access/models.cr
@@ -85,13 +85,13 @@ module Lenel::OpenAccess::Models
 
   struct Badge < Element
     getter badgekey : Int32
-    getter activate : Time
-    getter deactivate : Time
-    getter id : Int64
-    getter personid : Int32
-    getter status : Int32
-    getter type : Int32
-    getter uselimit : Int32
+    getter activate : Time?
+    getter deactivate : Time?
+    getter id : Int64?
+    getter personid : Int32?
+    getter status : Int32?
+    getter type : Int32?
+    getter uselimit : Int32?
   end
 
   struct BadgeType < Element


### PR DESCRIPTION
feat(lenel/openaccess): add more funcs; make badge response fields optional

- these new funcs are required for a logic driver in use by a client.
- In my testing with a live Lenel system I've found that some Badge responses only have `.id`, thus the change to the model to make those fields optional to ensure the response can be parsed without error.