### PR TITLE
fix(vergesense): Type of Space.People.coordinates

### DIFF
--- a/drivers/vergesense/models.cr
+++ b/drivers/vergesense/models.cr
@@ -58,6 +58,6 @@ module Vergesense
     include JSON::Serializable
 
     property count : UInt32?
-    property coordinates : Array( Array(Float64)? )?
+    property coordinates : Array(Array(Float64)?)?
   end
 end

--- a/drivers/vergesense/models.cr
+++ b/drivers/vergesense/models.cr
@@ -58,6 +58,6 @@ module Vergesense
     include JSON::Serializable
 
     property count : UInt32?
-    property coordinates : Array(Array(Array(Float64)))?
+    property coordinates : Array( Array(Float64)? )?
   end
 end

--- a/drivers/vergesense/vergesense_api_spec.cr
+++ b/drivers/vergesense/vergesense_api_spec.cr
@@ -156,14 +156,12 @@ DriverSpecs.mock_driver "Vergesense::VergesenseAPI" do
       "count": 21,
       "coordinates": [
         [
-          [
-            2.2673,
-            4.3891
-          ],
-          [
-            6.2573,
-            1.5303
-          ]
+          2.2673,
+          4.3891
+        ],
+        [
+          6.2573,
+          1.5303
         ]
       ],
       "distances": {
@@ -192,7 +190,7 @@ DriverSpecs.mock_driver "Vergesense::VergesenseAPI" do
         "geometry"        => {"type" => "Polygon", "coordinates" => [[[93.850772, 44.676952], [93.850739, 44.676929], [93.850718, 44.67695], [93.850751, 44.676973], [93.850772, 44.676952], [93.850772, 44.676952]]]},
         "people"          => {
           "count"       => 21,
-          "coordinates" => [[[2.2673, 4.3891], [6.2573, 1.5303]]],
+          "coordinates" => [[2.2673, 4.3891], [6.2573, 1.5303]],
         },
         "timestamp"       => "2019-08-21T21:10:25Z",
         "motion_detected" => true,


### PR DESCRIPTION
Space.People.coordinates is an array of arrays of Float (2 deep not 3), as per https://vergesense.readme.io/reference/events:
```
type SpaceReportEvent = {
  ...
  people: {
      // array of arrays of [x,y] coordinate pairs for each person detected by a device
      coordinates: [Array<[Number, Number]>?],
```