### PR TITLE
Vergesense: space_ref_id can be null

### DIFF
--- a/drivers/vergesense/models.cr
+++ b/drivers/vergesense/models.cr
@@ -58,6 +58,6 @@ module Vergesense
     include JSON::Serializable
 
     property count : UInt32?
-    property coordinates : Array( Array(Float64)? )?
+    property coordinates : Array(Array(Float64)?)?
   end
 end

--- a/drivers/vergesense/models.cr
+++ b/drivers/vergesense/models.cr
@@ -32,7 +32,7 @@ module Vergesense
 
     property building_ref_id : String?
     property floor_ref_id : String?
-    property space_ref_id : String
+    property space_ref_id : String?
     property space_type : String?
     property name : String?
     property capacity : UInt32?

--- a/drivers/vergesense/models.cr
+++ b/drivers/vergesense/models.cr
@@ -58,6 +58,6 @@ module Vergesense
     include JSON::Serializable
 
     property count : UInt32?
-    property coordinates : Array(Array(Array(Float64)))?
+    property coordinates : Array( Array(Float64)? )?
   end
 end

--- a/drivers/vergesense/vergesense_api_spec.cr
+++ b/drivers/vergesense/vergesense_api_spec.cr
@@ -156,14 +156,12 @@ DriverSpecs.mock_driver "Vergesense::VergesenseAPI" do
       "count": 21,
       "coordinates": [
         [
-          [
-            2.2673,
-            4.3891
-          ],
-          [
-            6.2573,
-            1.5303
-          ]
+          2.2673,
+          4.3891
+        ],
+        [
+          6.2573,
+          1.5303
         ]
       ],
       "distances": {
@@ -192,7 +190,7 @@ DriverSpecs.mock_driver "Vergesense::VergesenseAPI" do
         "geometry"        => {"type" => "Polygon", "coordinates" => [[[93.850772, 44.676952], [93.850739, 44.676929], [93.850718, 44.67695], [93.850751, 44.676973], [93.850772, 44.676952], [93.850772, 44.676952]]]},
         "people"          => {
           "count"       => 21,
-          "coordinates" => [[[2.2673, 4.3891], [6.2573, 1.5303]]],
+          "coordinates" => [[2.2673, 4.3891], [6.2573, 1.5303]],
         },
         "timestamp"       => "2019-08-21T21:10:25Z",
         "motion_detected" => true,


### PR DESCRIPTION
a vergesense api response has been seen with `space.space_ref_id: null`, so we'll need to handle it.
The values appear to be human made strings (friendly names) not guids.

Will an additional change be needed in order to ensure `update_floor_space` func still works when space_ref_id is null?
https://github.com/PlaceOS/drivers/blob/master/drivers/vergesense/vergesense_api.cr#L122
`floor_space = floor.spaces.find { |space| space.space_ref_id == remote_space.space_ref_id }`