### PR TITLE
Router / room logic

### DIFF
--- a/drivers/place/meet.cr
+++ b/drivers/place/meet.cr
@@ -47,7 +47,7 @@ class Place::Meet < PlaceOS::Driver
   end
 
   # Set the volume of a signal node within the system.
-  def volume(input_or_output : String, level : Int64)
+  def volume(level : Int32, input_or_output : String)
     logger.info { "setting volume on #{input_or_output} to #{level}" }
     node = signal_node input_or_output
     node.proxy.volume level

--- a/drivers/place/meet_spec.cr
+++ b/drivers/place/meet_spec.cr
@@ -74,12 +74,14 @@ DriverSpecs.mock_driver "Place::Meet" do
   status["outputs"].as_a.should contain("Display_1")
   status["output/Display_1"]["inputs"].should eq(["Foo", "Bar"])
 
+  exec(:power, true).get
+  status["active"].should eq true
+
   exec(:route, "Foo", "Display_1").get
   status["output/Display_1"]["source"].should eq(status["input/Foo"]["ref"])
+  system(:Display_1)["power"].should eq(true)
 
-  exec(:mute, "Display_1").get
+
+  exec(:mute, true, "Display_1").get
   status["output/Display_1"]["mute"].should be_true
-
-  exec(:powerup).get
-  status["active"].should eq true
 end

--- a/drivers/place/meet_spec.cr
+++ b/drivers/place/meet_spec.cr
@@ -32,6 +32,10 @@ class Display < DriverSpecs::MockDriver
   )
     self[:mute] = state
   end
+
+  def volume(level : Int32)
+    self[:volume] = level
+  end
 end
 
 class Switcher < DriverSpecs::MockDriver
@@ -79,9 +83,12 @@ DriverSpecs.mock_driver "Place::Meet" do
 
   exec(:route, "Foo", "Display_1").get
   status["output/Display_1"]["source"].should eq(status["input/Foo"]["ref"])
-  system(:Display_1)["power"].should eq(true)
-
+  system(:Display_1)["power"].should be_true
 
   exec(:mute, true, "Display_1").get
   status["output/Display_1"]["mute"].should be_true
+
+  exec(:volume, 50, "Display_1").get
+  status["output/Display_1"]["volume"].should eq(50)
+  system(:Display_1)["volume"].should eq(50)
 end

--- a/drivers/place/router.cr
+++ b/drivers/place/router.cr
@@ -237,29 +237,7 @@ class Place::Router < PlaceOS::Driver
       :ok
     end
 
-    # Set mute *state* on *input_or_output*.
-    #
-    # If the device supports local muting this will be activated, or the closest
-    # mute source found and routed.
-    def mute(input_or_output : String, state : Bool = true)
-      logger.debug { "#{state ? "muting" : "unmuting"} #{input_or_output}" }
-
-      node = signal_node input_or_output
-      node.proxy.mute state
-      node["mute"] = state
-
-      # TODO: implement graph based muting
-      # if state
-      #   route "MUTE", input_or_output
-      # else
-      #   ...
-      # end
-    end
-
-    # Disable signal muting on *input_or_output*.
-    def unmute(input_or_output : String)
-      mute input_or_output, false
-    end
+    # TODO: implement graph based muting
   end
 
   include Core

--- a/drivers/place/router.cr
+++ b/drivers/place/router.cr
@@ -206,20 +206,20 @@ class Place::Router < PlaceOS::Driver
           nil
         in SignalGraph::Edge::Active
           lazy do
+            next_node.source = siggraph[src].source
+
             # OPTIMIZE: split this to perform an inital pass to build a hash
             # from Driver::Proxy => [Edge::Active] then form the minimal set of
             # execs that satisfies these.
             mod = proxy_for edge.mod
-            res = case func = edge.func
-                  in SignalGraph::Edge::Func::Mute
-                    mod.mute func.state, func.index
-                  in SignalGraph::Edge::Func::Select
-                    mod.switch_to func.input
-                  in SignalGraph::Edge::Func::Switch
-                    mod.switch({func.input => [func.output]})
-                  end
-            next_node.source = siggraph[src].source
-            res
+            case func = edge.func
+            in SignalGraph::Edge::Func::Mute
+              mod.mute func.state, func.index
+            in SignalGraph::Edge::Func::Select
+              mod.switch_to func.input
+            in SignalGraph::Edge::Func::Switch
+              mod.switch({func.input => [func.output]})
+            end
           end
         end
       end

--- a/drivers/place/router/signal_graph/node.cr
+++ b/drivers/place/router/signal_graph/node.cr
@@ -45,6 +45,10 @@ class Place::Router::SignalGraph
         self[key] = JSON::Any.new value
       end
 
+      def []=(key, value : Int)
+        self[key] = JSON::Any.new value.to_i64
+      end
+
       def []=(key, value : Array)
         self[key] = JSON::Any.new value.map { |x| JSON::Any.new x }
       end

--- a/drivers/place/router/signal_graph/node.cr
+++ b/drivers/place/router/signal_graph/node.cr
@@ -70,13 +70,13 @@ class Place::Router::SignalGraph
       #   Ref.resolve("Display_1:hdmi", "sys-abc123")
       #   # => DeviceInput(sys: "sys-abc123", mod: {"Display", 1}, input: "hdmi")
       #
-      def self.resolve(key : String, sys = nil)
+      def self.resolve?(key : String, sys = nil)
         ref = key.includes?('/') ? key : "#{sys}/#{key}"
         {% begin %}
           {% for type in @type.subclasses %}
             {{type}}.parse?(ref) || \
           {% end %}
-          raise "malformed node ref: \"#{key}\""
+          nil
         {% end %}
       end
 

--- a/drivers/place/router_spec.cr
+++ b/drivers/place/router_spec.cr
@@ -77,9 +77,6 @@ DriverSpecs.mock_driver "Place::Router" do
   exec(:route, "Foo", "Display_1").get
   status["output/Display_1"]["source"].should eq(status["input/Foo"]["ref"])
 
-  exec(:mute, "Display_1").get
-  status["output/Display_1"]["mute"].should be_true
-
   expect_raises(
     PlaceOS::Driver::RemoteException,
     %(unknown signal node "Baz" - did you mean "Bar"?)

--- a/drivers/place/router_spec.cr
+++ b/drivers/place/router_spec.cr
@@ -79,4 +79,11 @@ DriverSpecs.mock_driver "Place::Router" do
 
   exec(:mute, "Display_1").get
   status["output/Display_1"]["mute"].should be_true
+
+  expect_raises(
+    PlaceOS::Driver::RemoteException,
+    %(unknown signal node "Baz" - did you mean "Bar"?)
+  ) do
+    exec(:route, "Foo", "Baz").get
+  end
 end


### PR DESCRIPTION
Added:
- **(breaking)** `PlaceOS::Meet` now implements the [`Powerable` interface](https://github.com/PlaceOS/driver/blob/master/src/placeos-driver/interface/powerable.cr) for system power.
- **(breaking)** `PlaceOS::Meet` now implements the [`Muteable` interface](https://github.com/PlaceOS/driver/blob/master/src/placeos-driver/interface/muteable.cr) for audio and video muting.
- Nicer error messages. When specifying an unknown input/output known refs are searched for a close match and suggested.

Changed:
- **(breaking)** Parameter order of `PlaceOS::Meet#volume` flipped to align with `mute` interfaces.
- Muting moved out of `PlaceOS::Router::Core` and into room logic.

Deprecated:
- `PlaceOS::Meet#powerup` - use `power(true)`
- `PlaceOS::Meet#shutdown` - use `power(false)`

Fixed:
- Incorrect event ordering that would cause outputs to attempt to switch input before powering on.