### PR TITLE
feat(meraki/locations): Apply device OS filter to list of Locations too

### DIFF
--- a/drivers/cisco/meraki/meraki_locations.cr
+++ b/drivers/cisco/meraki/meraki_locations.cr
@@ -654,6 +654,11 @@ class Cisco::Meraki::Locations < PlaceOS::Driver
         existing = @locations[client_mac]?
 
         logger.debug { "parsing new observation for #{client_mac}" } if @debug_webhook
+        # If a filter is set, then ignore this device unless it matches
+        if @regex_filter_device_os && observation.os && /#{@regex_filter_device_os}/.match(observation.os.not_nil!).nil?
+          logger.debug { "FILTERED OUT #{client_mac}: OS did not match" } if @debug_webhook
+          next
+        end
         location = parse(existing, ignore_older, drift_older, observation)
         if location
           @locations[client_mac] = location


### PR DESCRIPTION
There is an existing, optional regex filter for device operating system `regex_filter_device_os`, that applied only to the `locate_user` method.
This change uses the same filter and applies it to all exposed Locations (often rendered in apps as "device dots" from AreaManagement bindings).

A common use case is if staff have a particular managed device type of interest (e.g. Windows 10 laptops, or iPhones), and the enterprise only wants to LOCATE and COUNT (e.g. real-time device dots and retrospective analytics) those specific devices, then the device os regex filter setting can be set, and `AreaMangement` driver's `duplication_factor` should be set to `1.0` 