### PR TITLE
ci: run one test at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Driver Report
         # Skip subset report if dependencies have changed
         if: ${{ !contains(steps.changes.outputs.files, 'shard.yml') && !contains(steps.changes.outputs.files, 'shard.lock')  }}
-        run: ./harness report ${{ steps.changes.outputs.files }}
+        run: ./harness report --tests=1 ${{ steps.changes.outputs.files }}
         env:
           CRYSTAL_VERSION: ${{ matrix.crystal }}
       - name: Upload failure logs
@@ -83,7 +83,7 @@ jobs:
           path: lib
           key: ${{ hashFiles('shard.lock') }}
       - name: Driver Report
-        run: ./harness report
+        run: ./harness report --tests=1
         env:
           CRYSTAL_VERSION: ${{ matrix.crystal }}
       - name: Upload failure logs


### PR DESCRIPTION
Until the driver test runner safely supports concurrent specs, we should run one spec at a time.