### PR TITLE
chore(harness): crystal 1.1.1 instead of 1.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   # Driver test harness
   drivers:
-    image: placeos/drivers-spec:crystal-${CRYSTAL_VERSION:-1.0.0}
+    image: placeos/drivers-spec:crystal-${CRYSTAL_VERSION:-1.1.1}
     restart: always
     container_name: placeos-drivers
     hostname: drivers
@@ -35,7 +35,7 @@ services:
 
   # Ensures shards are installed.
   install-shards:
-    image: crystallang/crystal:${CRYSTAL_VERSION:-1.0.0}-alpine
+    image: crystallang/crystal:${CRYSTAL_VERSION:-1.1.1}-alpine
     restart: "no"
     working_dir: /wd
     command: ash -c 'shards check -q || shards install'


### PR DESCRIPTION
Update default driver test harness crystal version to 1.1.1

Tested briefly OK (ubuntu 20.04 in WSL2, Win10) with `./harness up` 
and compiled a driver that used Time `.step` (new in 1.1.0), which was not compiling in 1.0.0