### PR TITLE
Gallagher update_cardholder being able to return nil as a good response

### DIFF
--- a/drivers/gallagher/rest_api.cr
+++ b/drivers/gallagher/rest_api.cr
@@ -271,7 +271,8 @@ class Gallagher::RestAPI < PlaceOS::Driver
     end
 
     response = patch(url, headers: @headers, body: payload)
-    Cardholder.from_json process(response)
+    result = process(response)
+    result.presence && Cardholder.from_json(result)
   end
 
   def disable_card(href : String)


### PR DESCRIPTION
forcing the response to be present if we want to return the object back. Gallagher api is returning a empty body but still successful response