### PR TITLE
feat(router): graph-based muting

### DIFF
--- a/drivers/place/router.cr
+++ b/drivers/place/router.cr
@@ -16,7 +16,7 @@ class Place::Router < PlaceOS::Driver
 
     Following configuration, this driver can be used to perform simple input → \
     output routing, regardless of intermediate hardware. Drivers it interacts \
-    with _must_ implement the `Switchable`, `InputSelection` or `Mutable` \
+    with _must_ implement the `Switchable`, `InputSelection` or `Muteable` \
     interfaces.
 
     Configuration is specified as a map of devices and their attached inputs. \
@@ -264,8 +264,6 @@ class Place::Router < PlaceOS::Driver
 
       :ok
     end
-
-    # TODO: implement graph based muting
   end
 
   include Core

--- a/drivers/place/router/signal_graph.cr
+++ b/drivers/place/router/signal_graph.cr
@@ -61,7 +61,19 @@ class Place::Router::SignalGraph
         g[output.id, input.id] = Edge::Active.new mod, func
       end
     end
-    # TODO: insert muting subgraph
+
+    if mod.muteable?
+      if outputs.empty?
+        output = Node::Device.new mod
+        func = Edge::Func::Mute.new true
+        g[output.id, Mute.id] = Edge::Active.new mod, func
+      else
+        outputs.each do |output|
+          func = Edge::Func::Mute.new true, output.output
+          g[output.id, Mute.id] = Edge::Active.new mod, func
+        end
+      end
+    end
   end
 
   # Construct a graph from a pre-parsed configuration.

--- a/drivers/place/router/signal_graph.cr
+++ b/drivers/place/router/signal_graph.cr
@@ -140,10 +140,12 @@ class Place::Router::SignalGraph
   #
   # Provides an `Iterator` that provides labels across each node, the edge, and
   # subsequent node.
-  def route(source : Node::Ref, destination : Node::Ref)
+  def route(source : Node::Ref, destination : Node::Ref, max_dist = nil)
     path = g.path destination.id, source.id, invert: true
 
     return nil unless path
+
+    return nil if max_dist && path.size > max_dist
 
     path.each_cons(2, true).map do |(succ, pred)|
       {


### PR DESCRIPTION
Adds support for graph-based mute activation.

Edges to a symbolic `MUTE` source are inserted for all devices without outputs (e.g. displays) and intermediate signal devices that implement the `Muteable` interface.
Muting may then be activated by routing from a `"MUTE"` input ref.
This will find the closest available blanking source, preferences an on-device mute, then falling back to an upstream blanking source such as that provided on a matrix switcher output.
An optional `max_dist` parameter may be specified to `route` execs to limit both this and other route operations. For example, to use on-device muting only: `route("MUTE", "foo", max_dist: 1)`.
