### PR TITLE
fix(cisco/meraki): Client.vlan is now a String not Int32

### DIFF
--- a/drivers/cisco/meraki/scanning_api.cr
+++ b/drivers/cisco/meraki/scanning_api.cr
@@ -127,7 +127,7 @@ module Cisco::Meraki
     @[JSON::Field(key: "recentDeviceMac")]
     property recent_device_mac : String?
     property ssid : String?
-    property vlan : Int32?
+    property vlan : String?
     property switchport : String?
     property status : String
     property notes : String?


### PR DESCRIPTION
On 3 of 3 meraki instances I have confirmed errors like: 
`Couldn't parse (Int32 | Nil) from \"153\" ... parsing Cisco::Meraki::Client#vlan`


```
module_name": "MerakiLocations",
    "index": 1,
    "message": "module raised: remote exception: Couldn't parse (Int32 | Nil) from \"153\" at line 1, column 508\n  parsing Cisco::Meraki::Client#vlan at line 1, column 501 (JSON::SerializableError) (PlaceOS::Driver::RemoteException) (PlaceOS::Driver::RemoteException)",
    "backtrace": [
        "/usr/share/crystal/src/json/serialization.cr:159:7 in 'initialize:__pull_for_json_serializable'",
        "repositories/drivers/drivers/cisco/meraki/scanning_api.cr:103:5 in 'new_from_json_pull_parser'",
        "repositories/drivers/drivers/cisco/meraki/scanning_api.cr:103:5 in 'new'",
        "/usr/share/crystal/src/json/from_json.cr:153:11 in 'new'",
        "/usr/share/crystal/src/json/from_json.cr:13:3 in 'from_json'",
        "repositories/drivers/drivers/cisco/meraki/dashboard.cr:145:22 in 'poll_clients'",
```


```
    "module_name": "MerakiLocations",
    "index": 1,
    "message": "module raised: remote exception: Couldn't parse (Int32 | Nil) from \"502\" at line 1, column 421\n  parsing Cisco::Meraki::Client#vlan at line 1, column 414 (JSON::SerializableError) (PlaceOS::Driver::RemoteException) (PlaceOS::Driver::RemoteException)",
    "backtrace": [
        "/usr/share/crystal/src/json/serialization.cr:159:7 in 'initialize:__pull_for_json_serializable'",
        "repositories/drivers/drivers/cisco/meraki/scanning_api.cr:52:5 in 'new_from_json_pull_parser'",
        "repositories/drivers/drivers/cisco/meraki/scanning_api.cr:52:5 in 'new'",
        "/usr/share/crystal/src/json/from_json.cr:153:11 in 'new'",
        "/usr/share/crystal/src/json/from_json.cr:13:3 in 'from_json'",
        "repositories/drivers/drivers/cisco/meraki/dashboard.cr:114:24 in 'poll_clients'",
```