### PR TITLE
Fixing property type on Floorsense::UserGroup

### DIFF
--- a/drivers/floorsense/models.cr
+++ b/drivers/floorsense/models.cr
@@ -172,7 +172,7 @@ module Floorsense
     @[JSON::Field(key: "ugroupid")]
     property id : Int32
     property name : String
-    property count : int32
+    property count : Int32
   end
 
   class UserLocation


### PR DESCRIPTION
There is a typo not he property count, it should be Int32 with Capital I