### PR TITLE
Improvements/floorsense reservation lockers

### DIFF
--- a/drivers/floorsense/desks_websocket.cr
+++ b/drivers/floorsense/desks_websocket.cr
@@ -174,8 +174,13 @@ class Floorsense::DesksWebsocket < PlaceOS::Driver
     @lockers = lockers
   end
 
-  def controller_list
-    response = get("/restapi/slave-list", headers: default_headers)
+  def controller_list(locker : Bool? = nil, desks : Bool? = nil)
+    query = URI::Params.build do |form|
+      form.add("locks", "true") if locker
+      form.add("desks", "true") if desks
+    end
+
+    response = get("/restapi/slave-list#{query}", headers: default_headers)
     controllers = parse response, Array(ControllerInfo)
 
     mappings = {} of Int32 => ControllerInfo
@@ -241,7 +246,7 @@ class Floorsense::DesksWebsocket < PlaceOS::Driver
 
   def get_locker_reservation(reservation_id : String,)
     query = URI::Params.build { |form|
-      form.add("resid", reservation_id) if user_id
+      form.add("resid", reservation_id) if reservation_id
     }
 
     response = get("/restapi/res?#{query}", headers: default_headers)

--- a/drivers/floorsense/desks_websocket.cr
+++ b/drivers/floorsense/desks_websocket.cr
@@ -244,7 +244,7 @@ class Floorsense::DesksWebsocket < PlaceOS::Driver
     check_success(response)
   end
 
-  def get_locker_reservation(reservation_id : String,)
+  def get_locker_reservation(reservation_id : String)
     query = URI::Params.build { |form|
       form.add("resid", reservation_id) if reservation_id
     }

--- a/drivers/floorsense/desks_websocket.cr
+++ b/drivers/floorsense/desks_websocket.cr
@@ -239,6 +239,15 @@ class Floorsense::DesksWebsocket < PlaceOS::Driver
     check_success(response)
   end
 
+  def get_locker_reservation(reservation_id : String,)
+    query = URI::Params.build { |form|
+      form.add("resid", reservation_id) if user_id
+    }
+
+    response = get("/restapi/res?#{query}", headers: default_headers)
+    parse response, LockerBooking
+  end
+
   def locker_reservation(
     locker_key : String,
     user_id : String,
@@ -265,10 +274,11 @@ class Floorsense::DesksWebsocket < PlaceOS::Driver
     parse response, LockerBooking
   end
 
-  def locker_reservations(active : Bool? = nil, user_id : String? = nil)
+  def locker_reservations(active : Bool? = nil, user_id : String? = nil, controller_id : String? = nil)
     query = URI::Params.build { |form|
       form.add("uid", user_id) if user_id
       form.add("active", "1") if active
+      form.add("cid", controller_id) if controller_id
     }
 
     response = get("/restapi/res-list?#{query}", headers: default_headers)


### PR DESCRIPTION
Expanding current driver with the following features

1. controller_list: can accept 2 parameters to be able to filter controllers if the have lockers, desks or booths.
2. method to get an individual reservation: Floorsense has a limitation which can't pull every reservation existing. So during sync it is possible not getting the reservation from Floorsense when query all of them, But we can know the id in specific to be requested.
3. the action res-list, also accepts cid parameter, which can help to pull reservations for a specific controller.