### PR TITLE
Feat/axiom logic

### DIFF
--- a/drivers/rhb_access/axiomroomlogic.cr
+++ b/drivers/rhb_access/axiomroomlogic.cr
@@ -6,13 +6,13 @@ class RHBAccess::AxiomRoomLogic < PlaceOS::Driver
   description "Abstracts room access for Axiom"
 
   default_settings({
-    axiom_door_ids: [] of String
+    axiom_door_ids: [] of String,
   })
 
   accessor axiom : AxiomXa
 
   @door_ids = [] of String
-  
+
   def on_load
     on_update
   end

--- a/drivers/rhb_access/axiomroomlogic.cr
+++ b/drivers/rhb_access/axiomroomlogic.cr
@@ -11,14 +11,14 @@ class RHBAccess::AxiomRoomLogic < PlaceOS::Driver
 
   accessor axiom : AxiomXa
 
-  @door_ids : Array(Int32) = [] of Int32
+  @door_ids = [] of String
   
   def on_load
     on_update
   end
 
   def on_update
-    @door_ids = setting(Array(Int32), :axiom_door_ids)
+    @door_ids = setting(Array(String), :axiom_door_ids)
   end
 
   def lock

--- a/drivers/rhb_access/axiomroomlogic.cr
+++ b/drivers/rhb_access/axiomroomlogic.cr
@@ -1,0 +1,35 @@
+require "placeos-driver"
+
+class RHBAccess::AxiomRoomLogic < PlaceOS::Driver
+  descriptive_name "Room Access Logic for Axiom rooms"
+  generic_name :RoomAccess
+  description "Abstracts room access for Axiom"
+
+  default_settings({
+    axiom_door_ids: [] of Int32
+  })
+
+  accessor axiom : AxiomXa
+
+  @door_ids : Array(Int32) = [] of Int32
+  
+  def on_load
+    on_update
+  end
+
+  def on_update
+    @door_ids = setting(Array(Int32), :axiom_door_ids)
+  end
+
+  def lock
+    @door_ids.map { |d| axiom.lock(d) }
+    self["locked_at"] = Time.local
+    self["doors_locked"] = true
+  end
+
+  def unlock
+    @door_ids.map { |d| axiom.unlock(d) }
+    self["unlocked_at"] = Time.local
+    self["doors_locked"] = false
+  end
+end

--- a/drivers/rhb_access/axiomroomlogic.cr
+++ b/drivers/rhb_access/axiomroomlogic.cr
@@ -6,7 +6,7 @@ class RHBAccess::AxiomRoomLogic < PlaceOS::Driver
   description "Abstracts room access for Axiom"
 
   default_settings({
-    axiom_door_ids: [] of Int32
+    axiom_door_ids: [] of String
   })
 
   accessor axiom : AxiomXa

--- a/drivers/rhb_access/axiomxa.cr
+++ b/drivers/rhb_access/axiomxa.cr
@@ -3,7 +3,7 @@ require "axio"
 
 class RHBAccess::Axiomxa < PlaceOS::Driver
   descriptive_name "RHB Access Axiomxa"
-  generic_name :Campus
+  generic_name :AxiomXa
   uri_base "http://127.0.0.1:60001"
 
   alias Client = Axio::Client


### PR DESCRIPTION
1. adds a super simple room logic that aggregates an array of axiom ids that will be locked/unlocked for the System to which the Logic is deployed to. For use with Trigger Actions. The only reason this logic driver exists is because [Trigger Actions don't utilise System Settings](https://github.com/PlaceOS/triggers/issues/32).

2. Changes the default generic_name of the Axiom driver from "Campus" to "AxiomXa"