### PR TITLE
feat(infosilem/logic): ignore container events

### DIFF
--- a/drivers/infosilem/models.cr
+++ b/drivers/infosilem/models.cr
@@ -13,6 +13,10 @@ module Infosilem
 
     @[JSON::Field(key: "EndTime", converter: Infosilem::DateTimeConvertor)]
     property endTime : Time
+
+    def duration
+      endTime - startTime
+    end
   end
 
   module DateTimeConvertor


### PR DESCRIPTION
An additional request from the users of this RoomSchedule logic driver.

There will be scenarios where events encompass other events. I'll call these "container events". They would like these events to not trigger automation (i.e. be ignored by RoomSchedule).

I think the sort I added here should reduce the processing from n^2 to nlogn.