### PR TITLE
feat(cisco/room_kit): default settings enable ppl counting

### DIFF
--- a/drivers/cisco/room_kit.cr
+++ b/drivers/cisco/room_kit.cr
@@ -28,10 +28,10 @@ class Cisco::RoomKit < PlaceOS::Driver
     },
     peripheral_id: "uuid",
     configuration: {
-      "Audio Microphones Mute"              => {"Enabled" => "False"},
-      "Audio Input Line 1 VideoAssociation" => {
-        "MuteOnInactiveVideo" => "On",
-        "VideoInputSource"    => 2,
+      "RoomAnalytics": => {
+          "PeopleCountOutOfCall": "On",
+          "PeoplePresenceDetector": "On",
+          "WakeupOnMotionDetection": "On"
       },
     },
     presets: {


### PR DESCRIPTION
Also the previous default settings would impact video routing which is usually very bad.