### PR TITLE
feat(lenel/openaccess): reader searching, raw lookup, event pagination

### DIFF
--- a/drivers/lenel/open_access.cr
+++ b/drivers/lenel/open_access.cr
@@ -275,12 +275,19 @@ class Lenel::OpenAccess < PlaceOS::Driver
     client.delete Cardholder, **args
   end
 
-  # List Logged Events
+  # List card readers matching a given filter
   @[Security(Level::Support)]
-  def list_events(filter : String)
-    client.get_logged_events filter
+  def search_readers(filter : String)
+    client.lookup Reader, filter
   end
 
+  # List Logged Events
+  @[Security(Level::Support)]
+  def list_events(filter : String, page_number : Int32? = nil)
+    client.get_logged_events(filter, page_number)
+  end
+
+  @[Security(Level::Support)]
   # List events that occured during a given time window. Default to past 24h.
   def list_events_in_range(
     filter : String,
@@ -289,7 +296,12 @@ class Lenel::OpenAccess < PlaceOS::Driver
   )
     til ||= Time.local
     from ||= til - 1.day
-    client.get_logged_events(filter + %( AND timestamp >= #{from} AND timestamp <= #{til}))
+    client.get_logged_events(filter + %( AND timestamp >= "#{from.to_s}" AND timestamp <= "#{til.to_s}"))
+  end
+
+  @[Security(Level::Support)]
+  def search(type_name : String, filter : String? = nil)
+    client.raw_lookup type_name, filter
   end
 end
 

--- a/drivers/lenel/open_access/client.cr
+++ b/drivers/lenel/open_access/client.cr
@@ -131,6 +131,21 @@ class Lenel::OpenAccess::Client
     ))[:item_list]
   end
 
+  def raw_lookup(
+    type_name : String,
+    filter : String? = nil,
+    page_number : Int32? = nil,
+    page_size : Int32? = 100,
+    order_by : String? = nil
+  )
+    params = HTTP::Params.new
+    args.each do |key, val|
+      params.add key.to_s, val.to_s unless val.nil?
+    end
+    response = transport.get(path: "/instances?version=1.0&#{params}")
+    response.body
+  end
+
   # Counts the number of instances of *entity*.
   #
   # *filter* may optionally be used to specify a subset of these.
@@ -169,22 +184,22 @@ class Lenel::OpenAccess::Client
   def get_logged_events(
     filter : String? = nil,
     page_number : Int32? = nil,
-    page_size : Int32? = nil,
+    page_size : Int32? = 100,
     order_by : String? = nil
-  ) : Array(Event)
+  )
     params = HTTP::Params.new
     args.each do |key, val|
-      params.add key.to_s, val unless val.nil?
+      params.add key.to_s, val.to_s unless val.nil?
     end
-    (~transport.get(
-      path: "/logged_events?version=1.0&#{params}",
-    ) >> NamedTuple(
-      page_number: Int32?,
-      page_size: Int32?,
-      total_pages: Int32,
-      total_items: Int32,
-      count: Int32,
-      item_list: Array(Event),
-    ))[:item_list]
+    response = transport.get(path: "/logged_events?version=1.0&#{params}")
+    response.body
+    # >> NamedTuple(
+    #   page_number: Int32?,
+    #   page_size: Int32?,1
+    #   total_pages: Int32,
+    #   total_items: Int32,
+    #   count: Int32,
+    #   item_list: Array(Event),
+    # ))[:item_list]
   end
 end

--- a/drivers/lenel/open_access/client.cr
+++ b/drivers/lenel/open_access/client.cr
@@ -193,13 +193,5 @@ class Lenel::OpenAccess::Client
     end
     response = transport.get(path: "/logged_events?version=1.0&#{params}")
     response.body
-    # >> NamedTuple(
-    #   page_number: Int32?,
-    #   page_size: Int32?,1
-    #   total_pages: Int32,
-    #   total_items: Int32,
-    #   count: Int32,
-    #   item_list: Array(Event),
-    # ))[:item_list]
   end
 end

--- a/drivers/lenel/open_access/models.cr
+++ b/drivers/lenel/open_access/models.cr
@@ -86,13 +86,10 @@ module Lenel::OpenAccess::Models
 
   struct Event < Element
     getter serial_number : Int32?
-
-    @[JSON::Field(converter: Lenel::TimeConverter)]
-    getter timestamp : Time
-
+    getter timestamp : Time?
     getter description : String?
-    getter controller_id : Int32?
-    getter device_id : Int32?
+    getter controller_id : Int32
+    getter device_id : Int32
     getter subdevice_id : Int32?
     getter segment_id : Int32?
     getter event_type : Int32
@@ -104,13 +101,13 @@ module Lenel::OpenAccess::Models
     getter badge_issue_code : Int32?
     getter asset_id : Int32?
     getter cardholder_key : Int32?
-    getter alarm_priority : Int32?
-    getter alarm_ack_blue_channel : Int32?
-    getter alarm_ack_green_channel : Int32?
-    getter alarm_ack_red_channel : Int32?
-    getter alarm_blue_channel : Int32?
-    getter alarm_green_channel : Int32?
-    getter alarm_red_channel : Int32?
+    # getter alarm_priority : Int32?
+    # getter alarm_ack_blue_channel : Int32?
+    # getter alarm_ack_green_channel : Int32?
+    # getter alarm_ack_red_channel : Int32?
+    # getter alarm_blue_channel : Int32?
+    # getter alarm_green_channel : Int32?
+    # getter alarm_red_channel : Int32?
     getter access_result : Int32?
     getter cardholder_entered : Bool?
     getter duress : Bool?
@@ -120,8 +117,8 @@ module Lenel::OpenAccess::Models
     getter cardholder_last_name : String?
     getter device_name : String?
     getter subdevice_name : String?
-    getter must_acknowledge : Bool?
-    getter must_mark_in_progress : Bool?
+    # getter must_acknowledge : Bool?
+    # getter must_mark_in_progress : Bool?
   end
 
   abstract struct Person < Element
@@ -162,5 +159,37 @@ module Lenel::OpenAccess::Models
 
   struct Cardholder < Person
     getter email : String
+  end
+
+  struct Reader < Element
+    getter accessMode : Int32?
+    getter address : Int32?
+    getter controlType : Int32?
+    getter extendedOpenTime : Int32?
+    getter extendedStrikeTime : Int32?
+    getter gatewayAddress : Int32?
+    getter gatewayIPPort : Int32?
+    getter offlineMode : Int32?
+    getter mode : Int32?
+    getter openTime : Int32?
+    getter panelID : Int32?
+    getter portNumber : Int32?
+    getter readerID : Int32?
+    getter readerNumber : Int32?
+    getter slaveID : Int32?
+    getter strikeTime : Int32?
+    getter timeAttendanceType : Int32?
+    getter aux1Name : String?
+    getter aux2Name : String?
+    getter aux3Name : String?
+    getter friendlyName : String?
+    getter gatewayHostName : String?
+    getter hostName : String?
+    getter name : String?
+    getter out1Name : String?
+    getter out2Name : String?
+    getter panelTypeName : String?
+    getter isPairedMaster : Bool?
+    getter isPairedSlave : Bool?
   end
 end

--- a/drivers/xy_sense/location_service_spec.cr
+++ b/drivers/xy_sense/location_service_spec.cr
@@ -33,18 +33,18 @@ class XYSenseMock < DriverSpecs::MockDriver
           capacity: 1,
           category: "Workpoint",
         },
-                 {
-                   id:       "xysense-desk-456-id",
-                   name:     "desk-456",
-                   capacity: 1,
-                   category: "Workpoint",
-                 },
-                 {
-                   id:       "xysense-area-567-id",
-                   name:     "area-567",
-                   capacity: 20,
-                   category: "Lobby",
-                 }],
+        {
+          id:       "xysense-desk-456-id",
+          name:     "desk-456",
+          capacity: 1,
+          category: "Workpoint",
+        },
+        {
+          id:       "xysense-area-567-id",
+          name:     "area-567",
+          capacity: 20,
+          category: "Lobby",
+        }],
       },
     }
 


### PR DESCRIPTION
Been running this modified version in production fine for a year.

Additional features work fine:
- pagination of events
- card reader searching
- raw lookups

low level alarm related fields of reader were commented out as they will likely never be used. 
high level alarm fields remain as they may be used in the future.

There is an existing behaviour that still needs to be improved. On module start, it won't immediately go into online state. Need to manually force it to check_status before it will go Online.