### PR TITLE
feat(microsoft/graph): new driver for direct ms graph api calls

### DIFF
--- a/drivers/microsoft/graph_api_advanced.cr
+++ b/drivers/microsoft/graph_api_advanced.cr
@@ -71,4 +71,11 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
     )
     response.body["value"]
   end
+
+  def list_users_managed_devices(user_id : String)
+    response = get(
+      "/v1.0/users/#{user_id}/managedDevices"
+    )
+    response.body["value"]
+  end
 end

--- a/drivers/microsoft/graph_api_advanced.cr
+++ b/drivers/microsoft/graph_api_advanced.cr
@@ -1,0 +1,74 @@
+require "placeos-driver"
+require "office365"
+
+class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
+  descriptive_name "Direct Access to Microsoft Graph API"
+  generic_name :MSGraphAPI
+
+  uri_base "https://graph.microsoft.com/"
+
+  default_settings({
+    credentials: {
+      tenant:        "",
+      client_id:     "",
+      client_secret: "",
+    },
+
+  })
+
+  alias GraphParams = NamedTuple(
+    tenant: String,
+    client_id: String,
+    client_secret: String,
+  )
+
+  def on_load
+    on_update
+  end
+
+  def on_update
+    credentials = setting(GraphParams, :credentials)
+    @client = Office365::Client.new(**credentials)
+  end
+
+  private def get(path : String, query_params : URI::Params? = nil)
+    @client.not_nil!.graph_request(
+      @client.not_nil!.graph_http_request(
+        request_method: "GET",
+        path: path,
+        query: query_params
+      )
+    )
+  end
+
+  private def post(path : String, query_params : URI::Params? = nil, body : String? = nil)
+    @client.not_nil!.graph_request(
+      @client.not_nil!.graph_http_request(
+        request_method: "POST",
+        path: path,
+        data: body,
+        query: query_params
+      )
+    )
+  end
+
+  private def put(path : String, query_params : URI::Params? = nil, body : String? = nil)
+    @client.not_nil!.graph_request(
+      @client.not_nil!.graph_http_request(
+        request_method: "PUT",
+        path: path,
+        data: body,
+        query: query_params
+      )
+    )
+  end
+
+  def list_managed_devices(filter_device_name : String? = nil)
+    query_params = filter_device_name ? URI::Params{"filter" => "deviceName eq #{filter_device_name}"} : nil
+    response = get(
+      "/v1.0/deviceManagement/managedDevices",
+      query_params
+    )
+    response.body["value"]
+  end
+end

--- a/drivers/microsoft/graph_api_advanced.cr
+++ b/drivers/microsoft/graph_api_advanced.cr
@@ -31,7 +31,7 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
     @client = Office365::Client.new(**credentials)
   end
 
-  def get(path : String, query_params : URI::Params? = nil)
+  private def get(path : String, query_params : URI::Params? = nil)
     @client.not_nil!.graph_request(
       @client.not_nil!.graph_http_request(
         request_method: "GET",
@@ -41,7 +41,12 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
     )
   end
 
-  def post(path : String, query_params : URI::Params? = nil, body : String? = nil)
+  @[Security(Level::Support)]
+  def get_request(path : String)
+    get(path)
+  end
+
+  private def post(path : String, query_params : URI::Params? = nil, body : String? = nil)
     @client.not_nil!.graph_request(
       @client.not_nil!.graph_http_request(
         request_method: "POST",
@@ -52,7 +57,12 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
     )
   end
 
-  def put(path : String, query_params : URI::Params? = nil, body : String? = nil)
+  @[Security(Level::Support)]
+  def post_request(path : String)
+    post(path)
+  end
+
+  private def put(path : String, query_params : URI::Params? = nil, body : String? = nil)
     @client.not_nil!.graph_request(
       @client.not_nil!.graph_http_request(
         request_method: "PUT",
@@ -61,6 +71,11 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
         query: query_params
       )
     )
+  end
+
+  @[Security(Level::Support)]
+  def put_request(path : String)
+    put(path)
   end
 
   def list_managed_devices(filter_device_name : String? = nil)

--- a/drivers/microsoft/graph_api_advanced.cr
+++ b/drivers/microsoft/graph_api_advanced.cr
@@ -31,7 +31,7 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
     @client = Office365::Client.new(**credentials)
   end
 
-  private def get(path : String, query_params : URI::Params? = nil)
+  def get(path : String, query_params : URI::Params? = nil)
     @client.not_nil!.graph_request(
       @client.not_nil!.graph_http_request(
         request_method: "GET",
@@ -41,7 +41,7 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
     )
   end
 
-  private def post(path : String, query_params : URI::Params? = nil, body : String? = nil)
+  def post(path : String, query_params : URI::Params? = nil, body : String? = nil)
     @client.not_nil!.graph_request(
       @client.not_nil!.graph_http_request(
         request_method: "POST",
@@ -52,7 +52,7 @@ class Microsoft::GraphAPIAdvanced < PlaceOS::Driver
     )
   end
 
-  private def put(path : String, query_params : URI::Params? = nil, body : String? = nil)
+  def put(path : String, query_params : URI::Params? = nil, body : String? = nil)
     @client.not_nil!.graph_request(
       @client.not_nil!.graph_http_request(
         request_method: "PUT",

--- a/shard.yml
+++ b/shard.yml
@@ -28,6 +28,9 @@ dependencies:
   place_calendar:
     github: PlaceOS/calendar
 
+  office365:
+    github: PlaceOS/office365
+
   placeos-compiler:
     github: placeos/compiler
 


### PR DESCRIPTION
I chose to use the placeos/office365 lib instead of placeos/calendar (extend the existing graph api calendar driver), as it doesn't appear possible to use `@client.graph_request` when @client is placeos/calendar instead of placeos/office365. 

Is this the right track? Or is there a better approach.

This compiles but is untested.