### PR TITLE
fix(cisco/ise): reference user by name instead of email

### DIFF
--- a/drivers/cisco/ise/network_access.cr
+++ b/drivers/cisco/ise/network_access.cr
@@ -92,7 +92,7 @@ class Cisco::Ise::NetworkAccess < PlaceOS::Driver
 
     raise "Failed to create internal user, code #{response.status_code}\n#{response.body}" unless response.success?
 
-    user = get_internal_user_by_email(email)
+    user = get_internal_user_by_name(name)
     user.password = password
     user
   end
@@ -153,15 +153,28 @@ class Cisco::Ise::NetworkAccess < PlaceOS::Driver
 
   def update_internal_user_password_by_id(id : String, password : String? = nil)
     password ||= generate_password
-    internal_user = get_internal_user_by_id(id)
 
-    response = put("/internaluser/#{internal_user.id}", body: {"InternalUser" => {"password" => password}}.to_json, headers: {
+    response = put("/internaluser/#{id}", body: {"InternalUser" => {"password" => password}}.to_json, headers: {
       "Accept"        => TYPE_HEADER,
       "Content-Type"  => TYPE_HEADER,
       "Authorization" => @basic_auth,
     })
 
-    raise "failed to get internal user by email, code #{response.status_code}\n#{response.body}" unless response.success?
+    raise "failed: #{response.status_code}: #{response.body}" unless response.success?
+
+    JSON.parse(response.body)
+  end
+
+  def update_internal_user_password_by_name(name : String, password : String? = nil)
+    password ||= generate_password
+
+    response = put("/internaluser/name/#{name}", body: {"InternalUser" => {"password" => password}}.to_json, headers: {
+      "Accept"        => TYPE_HEADER,
+      "Content-Type"  => TYPE_HEADER,
+      "Authorization" => @basic_auth,
+    })
+
+    raise "failed: #{response.status_code}: #{response.body}" unless response.success?
 
     JSON.parse(response.body)
   end

--- a/drivers/place/booking_notifier.cr
+++ b/drivers/place/booking_notifier.cr
@@ -398,7 +398,7 @@ class Place::BookingNotifier < PlaceOS::Driver
 
   def update_network_user_password(user_email : String, password : String)
     # Check if they already exist
-    response = network_provider.update_internal_user_password_by_email(user_email, password).get
+    response = network_provider.update_internal_user_password_by_name(user_email, password).get
     logger.debug { "Response from Network Identity provider for lookup of #{user_email} was:\n#{response}" } if @debug
   rescue # todo: catch the specific error where the user already exists, instead of any error. Catch other errors in seperate rescue
     # Create them if they don't already exist

--- a/drivers/place/event_mailer.cr
+++ b/drivers/place/event_mailer.cr
@@ -162,7 +162,7 @@ class Place::EventMailer < PlaceOS::Driver
 
   def update_network_user_password(user_email : String, password : String)
     # Check if they already exist
-    response = network_provider.update_internal_user_password_by_email(user_email, password).get
+    response = network_provider.update_internal_user_password_by_name(user_email, password).get
     logger.debug { "Response from Network Identity provider for lookup of #{user_email} was:\n#{response}" } if @debug
   rescue # todo: catch the specific error where the user already exists, instead of any error. Catch other errors in seperate rescue
     # Create them if they don't already exist

--- a/drivers/place/visitor_mailer.cr
+++ b/drivers/place/visitor_mailer.cr
@@ -338,7 +338,7 @@ class Place::VisitorMailer < PlaceOS::Driver
 
   def update_network_user_password(user_email : String, password : String)
     # Check if they already exist
-    response = network_provider.update_internal_user_password_by_email(user_email, password).get
+    response = network_provider.update_internal_user_password_by_name(user_email, password).get
     logger.debug { "Response from Network Identity provider for lookup of #{user_email} was:\n#{response}" } if @debug
   rescue # todo: catch the specific error where the user already exists, instead of any error. Catch other errors in seperate rescue
     # Create them if they don't already exist


### PR DESCRIPTION
I was investigating an issue on a production deployment where I was running an older version of the ise driver which created users with their name as a random string instead of their email address. Due to the mismatch between the logic drivers and the ise service driver, 2 accounts were created for each user (with the same email address), one where name was a random string (created on the very first booking by a new ise user) and one where name=email (created in the subsequent booking).

This commit resolves the issue by always using the name field (which will contain the email) as the lookup.
It's also more efficient as the name field can directly access api objects, where as email requires a lookup (to get id or name), before an object can be updated or returned.