### PR TITLE
fix(docker-compose): update redis and install-shards image to multi-arch images tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       CRYSTAL_PATH: lib:/lib/local-shards:/usr/share/crystal/src
       REDIS_URL: redis://redis:6379
       TZ: $TZ
+    cap_add:
+      - "SYS_PTRACE"
+    security_opt:
+      - "seccomp:unconfined"
 
   build:
     image: placeos/build:${PLACE_BUILD_TAG:-latest}
@@ -48,7 +52,7 @@ services:
       TZ: $TZ
 
   redis:
-    image: eqalpha/keydb:alpine
+    image: eqalpha/keydb
     restart: always
     hostname: redis
     environment:
@@ -56,10 +60,11 @@ services:
 
   # Ensures shards are installed.
   install-shards:
-    image: crystallang/crystal:${CRYSTAL_VERSION:-latest}-alpine
+    image: placeos/crystal:${CRYSTAL_VERSION:-latest}
     restart: "no"
     working_dir: /wd
-    command: ash -c 'shards check -q || shards install'
+    entrypoint: ''
+    command: sh -c 'shards check -q || shards install'
     environment:
       SHARDS_OPTS: "--ignore-crystal-version"
     volumes:


### PR DESCRIPTION

**Description of the change**

Update `docker-compose` file to use images which support multi-architecture.

**Benefits**

Developers running on AMD or ARM64 machines should be able to use images specific for their architecture.

**Possible drawbacks**

  None