### PR TITLE
Fix/johnson control/send command headers

### DIFF
--- a/drivers/johnson_controls/metasys.cr
+++ b/drivers/johnson_controls/metasys.cr
@@ -242,7 +242,7 @@ class JohnsonControls::Metasys < PlaceOS::Driver
   end
 
   private def put_request(path : String, body)
-    put(path, headers: {"Authorization" => get_token, "Content-Type" => "application/json"}, body: body.to_json)
+    put(path, headers: {"Authorization" => get_token , "Content-Type" => CONTENT_TYPE}, body: body.to_json)
   end
 
   @[Security(Level::Support)]

--- a/drivers/johnson_controls/metasys.cr
+++ b/drivers/johnson_controls/metasys.cr
@@ -148,6 +148,13 @@ class JohnsonControls::Metasys < PlaceOS::Driver
     GetObjectAttributesWithSamplesResponse.from_json(response.body)
   end
 
+  def get_single_object_presentValue(id : String) : GetSingleObjectPresentValueResponse
+    response = get_request("/objects/#{id}/attributes/presentValue")
+    raise "request failed with #{response.status_code}\n#{response.body}" unless response.success?
+
+    GetSingleObjectPresentValueResponse.from_json(response.body)
+  end
+
   def get_samples_for_an_object_attribute(id : String, attribute_id : String, start_time : String, end_time : String, page : Int32 = 1, page_size : Int32 = 10) : GetSamplesForAnObjectAttributeResponse
     response = get_request("/objects/#{id}/attributes/#{attribute_id}/samples",
       start_time: start_time,

--- a/drivers/johnson_controls/metasys.cr
+++ b/drivers/johnson_controls/metasys.cr
@@ -242,7 +242,7 @@ class JohnsonControls::Metasys < PlaceOS::Driver
   end
 
   private def put_request(path : String, body)
-    put(path, headers: {"Authorization" => get_token}, body: body.to_json)
+    put(path, headers: {"Authorization" => get_token, "Content-Type" => "application/json"}, body: body.to_json)
   end
 
   @[Security(Level::Support)]

--- a/drivers/johnson_controls/metasys_models.cr
+++ b/drivers/johnson_controls/metasys_models.cr
@@ -228,6 +228,31 @@ module JohnsonControls
     property object_url : String
   end
 
+  class GetSingleObjectPresentValueResponse
+    include JSON::Serializable
+
+    class Item
+      include JSON::Serializable
+
+      class Value
+        include JSON::Serializable
+
+        @[JSON::Field(key: "value")]
+        property value : String?
+
+        @[JSON::Field(key: "reliability")]
+        property reliability : String?
+
+        @[JSON::Field(key: "priority")]
+        property next : String?
+      end
+      @[JSON::Field(key: "presentValue")]
+      property presentValue : Value
+    end
+    @[JSON::Field(key: "item")]
+    property item : Item
+  end
+
   class SamplesResponse
     include JSON::Serializable
 


### PR DESCRIPTION
**Description of the change**

Added content_type to headers for put request when send command is executed
 per api documentation
**Benefits**

The api was failing before this quick fix

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using # or link directly) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
