### PR TITLE
feat(placeos/room-events): add list_users func

### DIFF
--- a/drivers/place/bookings.cr
+++ b/drivers/place/bookings.cr
@@ -40,10 +40,10 @@ class Place::Bookings < PlaceOS::Driver
     room_image: "https://domain.com/room_image.svg",
     sensor_mac: "device-mac",
 
-    hide_meeting_details: false,
-    hide_meeting_title:   false,
+    hide_meeting_details:      false,
+    hide_meeting_title:        false,
     enable_end_meeting_button: false,
-    max_user_search_results: 20,
+    max_user_search_results:   20,
 
     # use this to expose arbitrary fields to influx
     # expose_for_analytics: {"binding" => "key->subkey"},

--- a/drivers/place/bookings.cr
+++ b/drivers/place/bookings.cr
@@ -213,7 +213,7 @@ class Place::Bookings < PlaceOS::Driver
 
   # Allow apps to search for attendees (to add to new bookings) via driver instead of via staff-api (as some role based accounts may not have MS Graph access)
   def list_users(query : String? = nil, limit : UInt32? = 20_u32)
-    calendar.list_users(query, limit).get.as_a
+    calendar.list_users(query, limit)
   end
 
   def book_now(period_in_seconds : Int64, title : String? = nil, owner : String? = nil)


### PR DESCRIPTION
Some role based accounts running the Booking panel app (via api key) may not have MS Graph API delegated permissions to query the AAD user directory (e.g. PlaceOS local accounts).

This change allows those apps to query users via a driver exec instead of via a staff-api call. A corresponding frontend change would also be required.