### PR TITLE
fix(placeos/visitor-mailer): determine host name with calendar driver…

### DIFF
--- a/drivers/place/bookings.cr
+++ b/drivers/place/bookings.cr
@@ -40,8 +40,8 @@ class Place::Bookings < PlaceOS::Driver
     room_image: "https://domain.com/room_image.svg",
     sensor_mac: "device-mac",
 
-    hide_meeting_details: false,
-    hide_meeting_title:   false,
+    hide_meeting_details:      false,
+    hide_meeting_title:        false,
     enable_end_meeting_button: false,
 
     # use this to expose arbitrary fields to influx

--- a/drivers/place/visitor_mailer_spec.cr
+++ b/drivers/place/visitor_mailer_spec.cr
@@ -1,0 +1,4 @@
+require "placeos-driver/spec"
+
+DriverSpecs.mock_driver "Place::VisitorMailer" do
+end


### PR DESCRIPTION
This change allows kiosk apps using API Keys associated with placeos local role based accounts (no MS Graph api delegated access) to determine the host name, using an AAD lookup via calendar driver instead of staff-api driver (delegated permissions).

Note that before deploying this visitor mailer driver update to any clients that REQUIRE the hostname lookup to use staff-api instead of calendar driver, be sure to set setting:
`determine_host_name_using: "staff-api-driver"`
to ensure that it functions as it used to.
