### PR TITLE
feat(gobright/api): add GET spaces/state request

### DIFF
--- a/drivers/gobright/api.cr
+++ b/drivers/gobright/api.cr
@@ -105,6 +105,22 @@ class GoBright::API < PlaceOS::Driver
     Array(Space).from_json fetch("/api/v2.0/spaces?#{params}")
   end
 
+  # Paged list of state per space, filtered by location/spacetype
+  def spaces_state(location : String? = nil, types : SpaceType | Array(SpaceType)? = nil)
+    params = URI::Params.build do |form|
+      form.add "pagingTake", "100"
+      form.add "filterLocationId", location.to_s unless location.presence.nil?
+      if types
+        types = types.is_a?(Array) ? types : [types]
+        types.each do |type|
+          form.add "filterSpaceType", type.value.to_s
+        end
+      end
+    end
+
+    Array(Space).from_json fetch("/api/v2.0/spaces/state?#{params}")
+  end
+
   # the list of booking occurances in the time period specified
   def bookings(starting : Int64, ending : Int64, location_id : String | Array(String)? = nil, space_id : String | Array(String)? = nil)
     params = URI::Params.build do |form|


### PR DESCRIPTION
Add support for GET spaces/state: 
https://t1b.gobright.cloud/swagger/index.html?url=/swagger/v1/swagger.json#/SpacesV2/SpacesV2_GetState

Mostly copied/pasted from existing GET spaces request (above it). Changed q param names only.

ALSO

Allow Gobright location services driver to specify a default spacetype for device_locations(). Just to workaround a new bug in GoBright API where no data is returned (instead of all) when no space type filter is specified.