### PR TITLE
Feat/placeos/rbp remote logging

### DIFF
--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -32,6 +32,7 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
     log_entry = LogEntry.from_json(payload)
     self[log_entry.device_id] ||= [] of JSON::Any
     self[log_entry.device_id] = self[log_entry.device_id].as_a.unshift(JSON::Any.new(log_entry.to_json)).truncate(0, @max_log_entries)
+    log_entry
   end
 
   class LogEntry

--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -27,8 +27,23 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
     self[:enabled] = @logging_enabled
   end
 
-  def post_event(payload : JSON::Any)
+  def post_event(payload : String)
     logger.debug { "Received: #{payload}" }
+    # log_entry = LogEntry.from_json(payload)
+    # self[log_entry.device_id] ||= [] of JSON::Any
+    # self[log_entry.device_id] = self[log_entry.device_id].as_a.unshift(log_entry).truncate(0, @max_log_entries)
   end
 
+  struct LogEntry
+    include JSON::Serializable
+    
+    property id : String
+    property device_id : String
+    property type : String
+    property subtype : String
+    property timestamp : Int32
+    property raw : JSON::Any
+    property data : JSON::Any
+    property metadata : JSON::Any
+  end
 end

--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -6,10 +6,12 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
   description %(Recieve logs streamed from Room Booking Panel app)
 
   default_settings({
+    enabled: false,
     max_log_entries:    1000,
-    debug: false
+    debug: false,
   })
 
+  @enabled : Bool = false
   @max_log_entries : UInt32 = 1000_u32
   @debug : Bool = false
 
@@ -18,8 +20,11 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
   end
 
   def on_update
+    @logging_enabled = setting?(Bool, "enabled") || true
     @max_log_entries = setting?(UInt32, "max_log_entries") || 1000_u32
     @debug = setting?(Bool, "debug") || false
+
+    self[:enabled] = @logging_enabled
   end
 
   def post_event(payload : JSON::Any)

--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -28,7 +28,7 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
   end
 
   def post_event(payload : String)
-    logger.debug { "Received: #{payload}" }
+    logger.debug { "Received: #{payload}" } if @debug
     log_entry = LogEntry.from_json(payload)
     self[log_entry.device_id] ||= [] of JSON::Any
     self[log_entry.device_id] = self[log_entry.device_id].as_a.unshift(JSON::Any.new(log_entry.to_json)).truncate(0, @max_log_entries)
@@ -40,7 +40,7 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
     
     property id : String
     property device_id : String
-    property type : String
+    property type : String  # Enum 'network' | 'console' | 'dom'
     property subtype : String
     property timestamp : Int32
     property raw : JSON::Any

--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -12,7 +12,7 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
   })
 
   @enabled : Bool = false
-  @max_log_entries : UInt32 = 1000_u32
+  @max_log_entries : Int32 = 1000
   @debug : Bool = false
 
   def on_load
@@ -21,7 +21,7 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
 
   def on_update
     @logging_enabled = setting?(Bool, "enabled") || true
-    @max_log_entries = setting?(UInt32, "max_log_entries") || 1000_u32
+    @max_log_entries = setting?(Int32, "max_log_entries") || 1000
     @debug = setting?(Bool, "debug") || false
 
     self[:enabled] = @logging_enabled
@@ -29,12 +29,12 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
 
   def post_event(payload : String)
     logger.debug { "Received: #{payload}" }
-    # log_entry = LogEntry.from_json(payload)
-    # self[log_entry.device_id] ||= [] of JSON::Any
-    # self[log_entry.device_id] = self[log_entry.device_id].as_a.unshift(log_entry).truncate(0, @max_log_entries)
+    log_entry = LogEntry.from_json(payload)
+    self[log_entry.device_id] ||= [] of JSON::Any
+    self[log_entry.device_id] = self[log_entry.device_id].as_a.unshift(JSON::Any.new(log_entry.to_json)).truncate(0, @max_log_entries)
   end
 
-  struct LogEntry
+  class LogEntry
     include JSON::Serializable
     
     property id : String

--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -29,8 +29,11 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
     self[:enabled] = @logging_enabled
   end
 
-  def post_event(payload : String)
+  def post_event(payload : JSON::Any | String)
     logger.debug { "Received: #{payload}" } if @debug
+
+    payload = payload.to_json if payload.is_a?(JSON::Any)
+    payload = payload.to_s if payload.is_a?(String)
 
     entry = Entry.from_json(payload)
 

--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -1,0 +1,29 @@
+require "placeos-driver"
+
+class Place::RbpRemoteLogger < PlaceOS::Driver
+  descriptive_name "Log Receiver for Room Booking Panel app"
+  generic_name :Logger
+  description %(Recieve logs streamed from Room Booking Panel app)
+
+  default_settings({
+    max_log_entries:    1000,
+    debug: false
+  })
+
+  @max_log_entries : UInt32 = 1000_u32
+  @debug : Bool = false
+
+  def on_load
+    on_update
+  end
+
+  def on_update
+    @max_log_entries = setting?(UInt32, "max_log_entries") || 1000_u32
+    @debug = setting?(Bool, "debug") || false
+  end
+
+  def post_event(payload : JSON::Any)
+    logger.debug { "Received: #{payload}" }
+  end
+
+end

--- a/drivers/place/rbp_remote_logger.cr
+++ b/drivers/place/rbp_remote_logger.cr
@@ -57,7 +57,7 @@ class Place::RbpRemoteLogger < PlaceOS::Driver
     property device_id : String
     property type : String # Enum 'network' | 'console' | 'dom'
     property subtype : String
-    property timestamp : Int32
+    property timestamp : Int64
     property raw : JSON::Any
     property data : JSON::Any
     property metadata : JSON::Any

--- a/drivers/place/rbp_remote_logger_spec.cr
+++ b/drivers/place/rbp_remote_logger_spec.cr
@@ -1,0 +1,4 @@
+require "placeos-driver/spec"
+
+DriverSpecs.mock_driver "Place::RbpRemoteLogger" do
+end

--- a/drivers/place/rbp_remote_logger_spec.cr
+++ b/drivers/place/rbp_remote_logger_spec.cr
@@ -1,4 +1,23 @@
 require "placeos-driver/spec"
+require "uuid"
 
 DriverSpecs.mock_driver "Place::RbpRemoteLogger" do
+  subpayload = {"id" => "1"}
+
+  payload = {
+    "id"        => "1",
+    "type"      => "3",
+    "subtype"   => "4",
+    "timestamp" => 5,
+    "raw"       => subpayload,
+    "data"      => subpayload,
+    "metadata"  => subpayload,
+  }
+
+  5.times do
+    payload.merge!({"device_id" => UUID.random.to_s})
+    entry = exec(:post_event, payload.to_json).get.not_nil!
+  end
+
+  status.[:entries].as_h.keys.size.should eq 5
 end

--- a/drivers/place/room_booking_approval_alternate.cr
+++ b/drivers/place/room_booking_approval_alternate.cr
@@ -7,13 +7,12 @@ class Place::RoomBookingApprovalAltnerative < PlaceOS::Driver
   description %(Room Booking approval for events where the room has not responded)
 
   default_settings({
-    notify_host_on_accept: true,
-    notify_host_on_decline: true,
-    default_accept_message: "Request accepted",
-    default_decline_message: "Request not accepted",
-    events_requiring_approval_are_tentative: true
+    notify_host_on_accept:                   true,
+    notify_host_on_decline:                  true,
+    default_accept_message:                  "Request accepted",
+    default_decline_message:                 "Request not accepted",
+    events_requiring_approval_are_tentative: true,
   })
-
 
   accessor calendar : Calendar_1
 
@@ -73,9 +72,7 @@ class Place::RoomBookingApprovalAltnerative < PlaceOS::Driver
         sys = system(system_id)
         if sys.exists?("Bookings", 1)
           if bookings = sys.get("Bookings", 1).status?(Array(PlaceCalendar::Event), "bookings")
-            @events_requiring_approval_are_tentative ? 
-              bookings.select! { |event| event.status == "tentative" }
-              : bookings.select! { |booking| room_attendee(booking).try(&.response_status).in?({"needsAction", "tentative"}) }
+            @events_requiring_approval_are_tentative ? bookings.select! { |event| event.status == "tentative" } : bookings.select! { |booking| room_attendee(booking).try(&.response_status).in?({"needsAction", "tentative"}) }
             results[system_id] = bookings unless bookings.empty?
           end
         end


### PR DESCRIPTION
**Description of the change**

This driver of type `Logger` should be deployed once to a building services system. It will listen for exec post_event requests from the Room Booking Panel frontend app. The app will bind to Logger.enabled (Bool) and if `true` then will continuously exec post_event for each js console line that it logs.

tested e2e:
- Success: it recieves post_event from the RBP app ok and outputs it raw to logger.debug.
- Need help: It is meant to parse the payload of post_event and expose it as module status (grouped by each tablet's System ID). Such that the historic logs of of each system can be browsed from the the module's exposed state, in reverse chronological order. 

**e.g. of desired module status:**
```
connected: true,
enabled: true,
sys-001: [
  {
      id : String
      device_id : String
      type : String  # Enum 'network' | 'console' | 'dom'
      subtype : String
      timestamp : Int32
      raw : JSON::Any
      data : JSON::Any
      metadata : JSON::Any
  },
  ... # more logs in reverse chronological order
],
sys-002: [...],
... # more system ids
```

Example real log entries received:

```
15:30:52.268 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-5593622451", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "log", "timestamp" => 1705649451878, "raw" => [["Binding:", "sys-F2pVj4Sp7Z"]], "data" => ["Binding:", "sys-F2pVj4Sp7Z"], "metadata" => nil} general.js:17:30
15:31:04.569 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-7522205630", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649464369, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:31:09.315 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-3485005780", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649469118, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:31:19.574 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-9397449457", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649479376, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:31:23.886 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-8152287509", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649483650, "raw" => [["%c[SVG VIEWER]%c[INPUT] %cEnding pinch/pan...", "color: #E91E63", "color: #ffb300", "color: default"]], "data" => ["[SVG VIEWER][INPUT] Ending pinch/pan..."], "metadata" => nil} general.js:17:30
15:31:34.582 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-8426332713", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649494381, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:31:42.685 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-2823672959", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649502477, "raw" => [["%c[SVG VIEWER]%c[INPUT] %cEnding pinch/pan...", "color: #E91E63", "color: #ffb300", "color: default"]], "data" => ["[SVG VIEWER][INPUT] Ending pinch/pan..."], "metadata" => nil} general.js:17:30
15:31:49.592 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-2951959271", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649509393, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:32:04.597 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-6825651295", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649524392, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:32:19.751 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-5646534856", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649539549, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:32:25.544 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-4323271738", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649545298, "raw" => [["%c[SVG VIEWER]%c[INPUT] %cEnding pinch/pan...", "color: #E91E63", "color: #ffb300", "color: default"]], "data" => ["[SVG VIEWER][INPUT] Ending pinch/pan..."], "metadata" => nil} general.js:17:30
15:32:29.282 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-1163309532", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649549074, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:32:34.744 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-17440947", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649554546, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:32:49.752 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-4251311221", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649569549, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil} general.js:17:30
15:33:04.753 [PlaceOS][WS] [DEBUG] mod-GSIL6Cio2K → Received: {"id" => "console-6165084844", "device_id" => "DEV-NGQ5IjCL", "type" => "console", "subtype" => "debug", "timestamp" => 1705649584553, "raw" => [["%c[PlaceOS]%c[WS] %cPong!", "color: #0288D1", "color:#009688", "color: default"]], "data" => ["[PlaceOS][WS] Pong!"], "metadata" => nil}
```

**Benefits**

Allows RBP frontend logs to be easily accessible from backoffice.
Allows retrospective troubleshooting of RBP issues.

**Possible drawbacks**
May take a lot of resources from core if many RBP apps are posting events. The RBP app is known to have many console events, all of which will be posted to this module.
Currently it is not possible to enable this logging system for a specific subset of RBP apps. It must be a whole building (or org) zone at a time. Subsequent frontend improvement will be requested after this version is working e2e.

