### PR TITLE
Fix/harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,10 @@ jobs:
           CRYSTAL_VERSION: ${{ matrix.crystal }}
       - name: Show build container logs
         if: ${{ failure() }}
-        run: docker-compose logs build
+        run: docker compose logs build
       - name: Show drivers container logs
         if: ${{ failure() }}
-        run: docker-compose logs drivers
+        run: docker compose logs drivers
       - name: Upload failure logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/harness
+++ b/harness
@@ -29,9 +29,9 @@ up() {
   echo '░░░ -> Pulling latest code...'
   git pull
   echo '░░░ -> Pulling latest images...'
-  docker-compose pull
+  docker compose pull
   echo '░░░ -> Starting environment...'
-  docker-compose up -d
+  docker compose up -d
   printf "░░░ The harness can be found at http://localhost:8085\n"
   echo '░░░ Stop the harness with `harness down`'
   say_done
@@ -39,13 +39,13 @@ up() {
 
 down() {
   echo '░░░ Stopping PlaceOS Driver Harness...'
-  docker-compose down --remove-orphans &> /dev/null
+  docker compose down --remove-orphans &> /dev/null
   say_done
 }
 
 format() {
   echo '░░░ Running `crystal tool format` over `drivers` and `repositories`'
-  docker-compose run \
+  docker compose run \
                      -v "${PWD}/drivers:/wd/drivers" \
                      -v "${PWD}/repositories:/wd/repositories" \
                      --no-deps \
@@ -58,16 +58,16 @@ format() {
 report() {
   echo '░░░ PlaceOS Driver Compilation Report'
   echo '░░░ Pulling images...'
-  docker-compose pull &> /dev/null
+  docker compose pull &> /dev/null
 
   # Ensure shards are satisfied before running the report
   echo '░░░ Installing shards...'
-  docker-compose run \
+  docker compose run \
                      --rm \
                      install-shards > /dev/null
 
   echo '░░░ Starting environment...'
-  docker-compose up -d &> /dev/null
+  docker compose up -d &> /dev/null
 
   exit_code=0
 
@@ -79,7 +79,7 @@ report() {
 }
 
 build() {
-  docker-compose run \
+  docker compose run \
                      --rm \
                      --no-deps \
                      -v "${PWD}/repositories:/app/repositories" \


### PR DESCRIPTION
**Description of the change**

Updates usage of `docker-compose` to `docker compose`

**Benefits**

`docker compose` is available in `docker` since version 20.10
it is no longer common to install `docker-compose` separately
some github ci containers require this change

**Possible drawbacks**

If a user of harness has a docker version < 20.10 they will need to update docker
