### PR TITLE
fix(place/booking_notifier): filter booking_type on event based actions

### DIFF
--- a/drivers/place/booking_approval_workflows.cr
+++ b/drivers/place/booking_approval_workflows.cr
@@ -235,6 +235,9 @@ class Place::BookingApprovalWorkflows < PlaceOS::Driver
     logger.debug { "received booking event payload: #{payload}" }
     booking_details = Booking.from_json payload
 
+# Only process booking types of interest
+    return unless booking_details.booking_type == @booking_type
+    
     # Ignore when a bookings state is updated
     return if {"process_state", "metadata_changed"}.includes?(booking_details.action)
 


### PR DESCRIPTION
**Description of the change**

<!-- Filters which module is used based on booking type. -->

**Benefits**

<!-- Prevents all approval emails being sent when one type of booking is made -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using # or link directly) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
