### PR TITLE
feat(place/meet): power on preview_outputs on startup

### DIFF
--- a/drivers/place/meet.cr
+++ b/drivers/place/meet.cr
@@ -233,6 +233,7 @@ class Place::Meet < PlaceOS::Driver
     sys = system
 
     if state
+      @local_preview_outputs.each { |device| sys[device].power true } # Power on preview displays
       apply_master_audio_default
       apply_camera_defaults
       apply_default_routes


### PR DESCRIPTION
When the system is started, power on all devices listed in the `preview_outputs` setting.
This needs to be tested when joined and unjoined, before rolling out.