### PR TITLE
feat(place/bookings): add timeline settings for booking panel

### DIFF
--- a/drivers/place/bookings.cr
+++ b/drivers/place/bookings.cr
@@ -42,10 +42,13 @@ class Place::Bookings < PlaceOS::Driver
     room_image:  "https://domain.com/room_image.svg",
     _sensor_mac: "device-mac",
 
-    show_tentative_meetings:      false,
-    hide_meeting_details:         false,
-    hide_meeting_title:           false,
-    enable_end_meeting_button:    false,
+    show_tentative_meetings:   false,
+    hide_meeting_details:      false,
+    hide_meeting_title:        false,
+    enable_end_meeting_button: false,
+    show_timeline:             false,
+    # one of: left, right, bottom, floating-left, floating-bottom
+    timeline_position:            "bottom",
     max_user_search_results:      20,
     poll_x_seconds_after_booking: 2,
 
@@ -195,6 +198,9 @@ class Place::Bookings < PlaceOS::Driver
     self[:max_duration] = setting?(Int32, :max_duration) || 480
 
     self[:enable_end_meeting_button] = setting?(Bool, :enable_end_meeting_button) || false
+
+    self[:show_timeline] = setting?(Bool, :show_timeline) || false
+    self[:timeline_position] = setting?(String, :timeline_position) || "bottom"
   end
 
   # This is how we check the rooms status

--- a/drivers/place/bookings_spec.cr
+++ b/drivers/place/bookings_spec.cr
@@ -17,6 +17,9 @@ DriverSpecs.mock_driver "Place::Bookings" do
   bookings = status[:bookings].as_a
   bookings.size.should eq(4)
 
+  status[:show_timeline].should eq(false)
+  status[:timeline_position].should eq("bottom")
+
   sleep 200.milliseconds
 
   status[:booked].should eq(true)


### PR DESCRIPTION
## Summary
- Expose `show_timeline` (bool, default `false`) and `timeline_position` (string, default `bottom`; valid: `left`, `right`, `bottom`, `floating-left`, `floating-bottom`) as status bindings in the Bookings driver
- Required by the booking panel timeline view frontend changes ([PPT-2570](https://acaprojects.atlassian.net/browse/PPT-2570))
- Spec asserts both defaults; harness passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PPT-2570]: https://acaprojects.atlassian.net/browse/PPT-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ